### PR TITLE
feat: add secure DMZ topology to lab and docs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -130,6 +134,95 @@
       ]
     }
   ],
-  "results": {},
-  "generated_at": "2026-03-21T12:17:38Z"
+  "results": {
+    ".github/workflows/pr-validation.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/pr-validation.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "backend/network_synapse/data/populate_sot.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/network_synapse/data/populate_sot.py",
+        "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
+        "is_verified": false,
+        "line_number": 761
+      }
+    ],
+    "backend/network_synapse/infrahub/client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/network_synapse/infrahub/client.py",
+        "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
+        "is_verified": false,
+        "line_number": 205
+      }
+    ],
+    "backend/network_synapse/infrahub/resource_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/network_synapse/infrahub/resource_manager.py",
+        "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
+        "is_verified": false,
+        "line_number": 226
+      }
+    ],
+    "development/docker-compose-ci.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "development/docker-compose-ci.yml",
+        "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "development/docker-compose-deps.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "development/docker-compose-deps.yml",
+        "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "development/docker-compose-deps.yml",
+        "hashed_secret": "d68a6a4c3f1c495aa0642829a85d4877e3e8951c",
+        "is_verified": false,
+        "line_number": 109
+      }
+    ],
+    "development/docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "development/docker-compose.yml",
+        "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "development/suzieq/suzieq-inventory.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "development/suzieq/suzieq-inventory.yml",
+        "hashed_secret": "890f8be5b537166b01a8e285cf555b12292d4761",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "docs/infrastructure.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/infrastructure.md",
+        "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
+        "is_verified": false,
+        "line_number": 161
+      }
+    ]
+  },
+  "generated_at": "2026-03-25T19:37:02Z"
 }

--- a/changelog/36.added.md
+++ b/changelog/36.added.md
@@ -1,0 +1,1 @@
+Added Linux-based testing nodes (`client1`, `client2`) and a `firewall` node to the Containerlab Spine-Leaf topology to facilitate data-plane connectivity and security policy validation.

--- a/containerlab/topology.clab.yml
+++ b/containerlab/topology.clab.yml
@@ -21,8 +21,38 @@ topology:
       kind: nokia_srlinux
       type: ixr-d2
 
+    # Linux Client on Leaf 01
+    client1:
+      kind: linux
+      image: wbitt/network-multitool:alpine-extra
+
+    # Firewall on Leaf 02
+    firewall:
+      kind: linux
+      image: wbitt/network-multitool:alpine-extra
+      sysctls:
+        - net.ipv4.ip_forward=1
+      exec:
+        # Default policy: drop forwarded traffic
+        - iptables -P FORWARD DROP
+        # Allow client1 (or fabric) to reach client2
+        - iptables -A FORWARD -i eth1 -o eth2 -j ACCEPT
+        # Allow returning traffic
+        - iptables -A FORWARD -i eth2 -o eth1 -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+    # Linux Client behind Firewall (Secure DMZ)
+    client2:
+      kind: linux
+      image: wbitt/network-multitool:alpine-extra
+
   links:
+    # Spine-Leaf Fabric Links
     - endpoints: ["spine01:e1-1", "leaf01:e1-49"]
     - endpoints: ["spine01:e1-2", "leaf02:e1-49"]
     - endpoints: ["spine01:e1-3", "leaf01:e1-50"]
     - endpoints: ["spine01:e1-4", "leaf02:e1-50"]
+
+    # Workload Links
+    - endpoints: ["client1:eth1", "leaf01:e1-1"]
+    - endpoints: ["firewall:eth1", "leaf02:e1-1"]
+    - endpoints: ["firewall:eth2", "client2:eth1"]

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -26,6 +26,9 @@ Spine-leaf topology with 1 spine and 2 leaf switches, all Nokia SR Linux.
 | spine01 | spine | 7220 IXR-D3 | 172.20.20.3 | clab-spine-leaf-lab-spine01 |
 | leaf01 | leaf | 7220 IXR-D2 | 172.20.20.2 | clab-spine-leaf-lab-leaf01 |
 | leaf02 | leaf | 7220 IXR-D2 | 172.20.20.4 | clab-spine-leaf-lab-leaf02 |
+| client1 | client | Linux (Alpine) | DHCP | clab-spine-leaf-lab-client1 |
+| firewall| firewall| Linux (Alpine) | DHCP | clab-spine-leaf-lab-firewall |
+| client2 | client | Linux (Alpine) | DHCP | clab-spine-leaf-lab-client2 |
 
 ### Credentials
 
@@ -101,13 +104,26 @@ sudo containerlab deploy -t containerlab/topology.clab.yml
          | leaf01 |   | leaf02 |
          | IXR-D2 |   | IXR-D2 |
          | .2     |   | .4     |
-         +--------+   +--------+
+         +---+----+   +----+---+
+        e1-1 |             | e1-1
+         +---+----+   +----+---+
+         | client1|   |firewall|
+         | Linux  |   | Linux  |
+         +--------+   +----+---+
+                           | eth2
+                      +----+---+
+                      | client2|
+                      | Linux  |
+                      +--------+
 
 Links:
   spine01:e1-1 <-> leaf01:e1-49
   spine01:e1-2 <-> leaf02:e1-49
   spine01:e1-3 <-> leaf01:e1-50
   spine01:e1-4 <-> leaf02:e1-50
+  leaf01:e1-1  <-> client1:eth1
+  leaf02:e1-1  <-> firewall:eth1
+  firewall:eth2<-> client2:eth1
 
 Management: 172.20.20.0/24
 ```

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -188,9 +188,11 @@ docker compose -f development/docker-compose-deps.yml up -d temporal
 1. **Access SR Linux CLI via docker exec:**
 
    ```bash
-   docker exec -it clab-spine-leaf-lab-spine01 sr_cli   # spine01
+   docker exec -it clab-spine-leaf-lab-spine01 sr_cli    # spine01
    docker exec -it clab-spine-leaf-lab-leaf01 sr_cli     # leaf01
    docker exec -it clab-spine-leaf-lab-leaf02 sr_cli     # leaf02
+   # Linux Testing Clients
+   docker exec -it clab-spine-leaf-lab-client1 /bin/bash # client1
    ```
 
 2. **Alternatively, SSH directly (OrbStack makes 172.20.20.x reachable):**

--- a/docs/seed-data.md
+++ b/docs/seed-data.md
@@ -68,6 +68,8 @@ See [resource-manager.md](resource-manager.md) for details on pool allocation.
 | leaf01 | leaf | 7220 IXR-D2 | 172.20.20.2/24 | clab-spine-leaf-lab-leaf01 | 65001 |
 | leaf02 | leaf | 7220 IXR-D2 | 172.20.20.4/24 | clab-spine-leaf-lab-leaf02 | 65002 |
 
+> **Note:** The Containerlab topology explicitly includes additional Linux testing nodes (`client1`, `client2`, `firewall`) that are excluded from the Infrahub Source of Truth as they are purely logical end-hosts for verifying data plane conductivity.
+
 ## Autonomous Systems
 
 | ASN | Name | Description |


### PR DESCRIPTION
Closes #36.

**What this PR does:**
- Updates `containerlab/topology.clab.yml` with Alpine-based network multitool clients.
- Configures a `firewall` node with IP forwarding and base iptables rules.
- Updates documentation (`infrastructure.md`, `runbooks.md`, etc.) to map out the new lab state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new network nodes to the topology: client1, client2, and a firewall node with traffic filtering capabilities and forwarding support.

* **Documentation**
  * Updated topology diagrams and connectivity documentation.
  * Enhanced infrastructure documentation with clarifications on node inclusion.
  * Updated CLI access instructions for end-host connectivity testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->