### PR TITLE
fix: replace removed VyOS image with Alpine + iptables firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ uv run invoke dev.deps            # Start infrastructure dependencies
 
 ## Lab Topology
 
-Nokia SR Linux spine-leaf fabric with VyOS firewall and Alpine clients, running via Containerlab natively on OrbStack (DooD):
+Nokia SR Linux spine-leaf fabric with Alpine Linux firewall and Alpine clients, running via Containerlab natively on OrbStack (DooD):
 
 - **spine01** (IXR-D3, AS65000) — 4 fabric links
 - **leaf01** (IXR-D2, AS65001) — 2 uplinks
 - **leaf02** (IXR-D2, AS65002) — 2 uplinks
-- **firewall** (VyOS 1.4) — attached to leaf02, separates pc1/pc2 zones
+- **firewall** (Alpine + iptables) — attached to leaf02, separates pc1/pc2 zones
 - **pc1** (Alpine) — client on leaf01
 - **pc2** (Alpine) — client behind firewall on leaf02
 - Underlay: eBGP on `/31` point-to-point links
@@ -178,7 +178,7 @@ Nokia SR Linux spine-leaf fabric with VyOS firewall and Alpine clients, running 
 # Nokia SR Linux CLI
 docker exec -it clab-spine-leaf-lab-spine01 sr_cli
 
-# VyOS firewall
+# Firewall (Alpine + iptables)
 docker exec -it clab-spine-leaf-lab-firewall /bin/bash
 
 # Alpine clients

--- a/changelog/110.fixed.md
+++ b/changelog/110.fixed.md
@@ -1,0 +1,1 @@
+Replace removed VyOS Docker image with Alpine + iptables for firewall node in Containerlab topology

--- a/containerlab/topology.clab.yml
+++ b/containerlab/topology.clab.yml
@@ -21,11 +21,13 @@ topology:
       kind: nokia_srlinux
       type: ixr-d2
 
-    # --- Firewall (VyOS) on Leaf 02 ---
+    # --- Firewall (Alpine + iptables) on Leaf 02 ---
     firewall:
       kind: linux
-      image: vyos/vyos:1.4-rolling-20240101
-      memory: 1GB
+      image: wbitt/network-multitool:alpine-extra
+      exec:
+        - sysctl -w net.ipv4.ip_forward=1
+        - apk add --no-cache iptables
 
     # --- Clients ---
     pc1:

--- a/containerlab/topology.clab.yml
+++ b/containerlab/topology.clab.yml
@@ -24,9 +24,10 @@ topology:
     # --- Firewall (Alpine + iptables) on Leaf 02 ---
     firewall:
       kind: linux
-      image: wbitt/network-multitool:alpine-extra
+      image: wbitt/network-multitool@sha256:00bf63b9e033362a4adf138c4b14d92bc6ce52446358fed4da14c2e16e8a64aa
+      sysctls:
+        net.ipv4.ip_forward: 1
       exec:
-        - sysctl -w net.ipv4.ip_forward=1
         - apk add --no-cache iptables
 
     # --- Clients ---

--- a/dev/skills/containerlab/SKILL.md
+++ b/dev/skills/containerlab/SKILL.md
@@ -31,8 +31,10 @@ topology:
       type: ixr-d2
     firewall:
       kind: linux
-      image: vyos/vyos:1.4-rolling-20240101
-      memory: 1GB
+      image: wbitt/network-multitool:alpine-extra
+      exec:
+        - sysctl -w net.ipv4.ip_forward=1
+        - apk add --no-cache iptables
     pc1:
       kind: linux
       image: wbitt/network-multitool:alpine-extra
@@ -71,7 +73,7 @@ docker exec -it clab-spine-leaf-lab-spine01 sr_cli
 docker exec -it clab-spine-leaf-lab-leaf01 sr_cli
 docker exec -it clab-spine-leaf-lab-leaf02 sr_cli
 
-# VyOS firewall
+# Firewall (Alpine + iptables)
 docker exec -it clab-spine-leaf-lab-firewall /bin/bash
 
 # Alpine clients

--- a/dev/skills/containerlab/SKILL.md
+++ b/dev/skills/containerlab/SKILL.md
@@ -31,9 +31,10 @@ topology:
       type: ixr-d2
     firewall:
       kind: linux
-      image: wbitt/network-multitool:alpine-extra
+      image: wbitt/network-multitool@sha256:00bf63b9e...
+      sysctls:
+        net.ipv4.ip_forward: 1
       exec:
-        - sysctl -w net.ipv4.ip_forward=1
         - apk add --no-cache iptables
     pc1:
       kind: linux


### PR DESCRIPTION
Closes #110

## Problem

The VyOS Docker image `vyos/vyos:1.4-rolling-20240101` has been removed from Docker Hub (VyOS rolling tags are ephemeral), causing `uv run invoke dev.lab-deploy` to fail.

## Solution

Replace with `wbitt/network-multitool:alpine-extra` (same image as pc1/pc2 workload nodes) with iptables installed at deploy via Containerlab `exec`. The firewall image is pinned to a sha256 digest for reproducibility, and IP forwarding uses declarative `sysctls`.

## Changes

- **`containerlab/topology.clab.yml`** — Swapped image (digest-pinned), added `sysctls` for IP forwarding + `exec` for iptables
- **`README.md`** — Updated lab topology description
- **`dev/skills/containerlab/SKILL.md`** — Updated example topology snippet
- **`changelog/110.fixed.md`** — Changelog fragment

## Testing

- Lab deploys successfully with all 6 nodes running
- Firewall node has iptables available and IP forwarding enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated lab topology documentation to reflect firewall implementation changes from VyOS to Alpine-based setup with iptables.
  * Updated network configuration settings to enable IPv4 forwarding in the lab topology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->