### PR TITLE
refactor(ci): de-duplicate Infrahub readiness wait into composite action

### DIFF
--- a/.github/actions/wait-for-infrahub-stack/action.yml
+++ b/.github/actions/wait-for-infrahub-stack/action.yml
@@ -1,0 +1,69 @@
+---
+name: Wait for Infrahub stack
+description: >
+  Wait until the CI Infrahub stack is ready to accept schema loads: the
+  infrahub-server responds and the infrahub-task-worker has registered with
+  its pool. POST /api/schema/load dispatches a Prefect flow, so without a
+  registered worker the request hangs for the full client timeout (see #123).
+
+inputs:
+  compose-file:
+    description: Path to the docker compose file running the stack.
+    required: false
+    default: development/docker-compose-ci.yml
+  server-url:
+    description: URL polled to decide infrahub-server is responding.
+    required: false
+    default: http://localhost:8000/api/schema/summary
+  server-timeout:
+    description: Seconds to wait for infrahub-server to respond.
+    required: false
+    default: "180"
+  worker-timeout:
+    description: Seconds to wait for infrahub-task-worker to register.
+    required: false
+    default: "120"
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for Infrahub health
+      shell: bash
+      env:
+        COMPOSE_FILE_PATH: ${{ inputs.compose-file }}
+        SERVER_URL: ${{ inputs.server-url }}
+        SERVER_TIMEOUT: ${{ inputs.server-timeout }}
+        WORKER_TIMEOUT: ${{ inputs.worker-timeout }}
+      run: |
+        compose() { docker compose -f "$COMPOSE_FILE_PATH" "$@"; }
+
+        echo "Waiting for infrahub-server to respond..."
+        for i in $(seq 1 "$SERVER_TIMEOUT"); do
+          if curl -sf "$SERVER_URL" > /dev/null 2>&1; then
+            echo "infrahub-server ready after ${i}s"
+            break
+          fi
+          if [ "$i" -eq "$SERVER_TIMEOUT" ]; then
+            echo "infrahub-server did not become ready in ${SERVER_TIMEOUT}s"
+            compose logs infrahub-server infrahub-task-manager
+            exit 1
+          fi
+          sleep 1
+        done
+
+        # POST /api/schema/load dispatches a Prefect flow — wait until the
+        # task-worker has registered with its pool, otherwise the request
+        # hangs for the full client timeout (see #123).
+        echo "Waiting for infrahub-task-worker to register..."
+        for i in $(seq 1 "$WORKER_TIMEOUT"); do
+          if compose logs infrahub-task-worker 2>/dev/null | grep -q "Worker .* started"; then
+            echo "infrahub-task-worker registered after ${i}s"
+            break
+          fi
+          if [ "$i" -eq "$WORKER_TIMEOUT" ]; then
+            echo "infrahub-task-worker did not register in ${WORKER_TIMEOUT}s"
+            compose logs infrahub-task-worker
+            exit 1
+          fi
+          sleep 1
+        done

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -292,39 +292,7 @@ jobs:
         run: docker compose -f development/docker-compose-ci.yml up -d
 
       - name: Wait for Infrahub health
-        run: |
-          compose() { docker compose -f development/docker-compose-ci.yml "$@"; }
-
-          echo "Waiting for infrahub-server to respond..."
-          for i in $(seq 1 180); do
-            if curl -sf http://localhost:8000/api/schema/summary > /dev/null 2>&1; then
-              echo "infrahub-server ready after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 180 ]; then
-              echo "infrahub-server did not become ready in 180s"
-              compose logs infrahub-server infrahub-task-manager
-              exit 1
-            fi
-            sleep 1
-          done
-
-          # POST /api/schema/load dispatches a Prefect flow — wait until the
-          # task-worker has registered with its pool, otherwise the request
-          # hangs for the full client timeout (see #123).
-          echo "Waiting for infrahub-task-worker to register..."
-          for i in $(seq 1 120); do
-            if compose logs infrahub-task-worker 2>/dev/null | grep -q "Worker .* started"; then
-              echo "infrahub-task-worker registered after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 120 ]; then
-              echo "infrahub-task-worker did not register in 120s"
-              compose logs infrahub-task-worker
-              exit 1
-            fi
-            sleep 1
-          done
+        uses: ./.github/actions/wait-for-infrahub-stack
 
       - name: Load schemas
         run: |
@@ -381,39 +349,7 @@ jobs:
         run: docker compose -f development/docker-compose-ci.yml up -d
 
       - name: Wait for Infrahub health
-        run: |
-          compose() { docker compose -f development/docker-compose-ci.yml "$@"; }
-
-          echo "Waiting for infrahub-server to respond..."
-          for i in $(seq 1 180); do
-            if curl -sf http://localhost:8000/api/schema/summary > /dev/null 2>&1; then
-              echo "infrahub-server ready after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 180 ]; then
-              echo "infrahub-server did not become ready in 180s"
-              compose logs infrahub-server infrahub-task-manager
-              exit 1
-            fi
-            sleep 1
-          done
-
-          # POST /api/schema/load dispatches a Prefect flow — wait until the
-          # task-worker has registered with its pool, otherwise the request
-          # hangs for the full client timeout (see #123).
-          echo "Waiting for infrahub-task-worker to register..."
-          for i in $(seq 1 120); do
-            if compose logs infrahub-task-worker 2>/dev/null | grep -q "Worker .* started"; then
-              echo "infrahub-task-worker registered after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 120 ]; then
-              echo "infrahub-task-worker did not register in 120s"
-              compose logs infrahub-task-worker
-              exit 1
-            fi
-            sleep 1
-          done
+        uses: ./.github/actions/wait-for-infrahub-stack
 
       - name: Load schemas
         run: |

--- a/changelog/126.changed.md
+++ b/changelog/126.changed.md
@@ -1,0 +1,1 @@
+Extract the duplicated CI "wait for Infrahub stack" readiness logic (server health + task-worker registration) into a reusable `wait-for-infrahub-stack` composite action, shared by the `schema-validation` and `integration-infrahub` jobs.


### PR DESCRIPTION
## Summary

The "Wait for Infrahub health" shell block — the `compose()` wrapper, the server-health poll loop, and the task-worker pool-registration log-grep loop — was duplicated verbatim between the `schema-validation` and `integration-infrahub` jobs in `.github/workflows/quality.yml`. Any future change (timeout tuning, log-pattern adjustment, extra readiness checks) had to land in two places and was easy to drift.

This extracts it into a reusable **composite action** at `.github/actions/wait-for-infrahub-stack/action.yml`, the GitHub-native idiom recommended in #126. Both jobs now invoke it via a single `uses: ./.github/actions/wait-for-infrahub-stack` step.

The action exposes inputs (with defaults matching the previous inline values) so the behaviour stays tunable in one place:
- `compose-file` (default `development/docker-compose-ci.yml`)
- `server-url` (default `http://localhost:8000/api/schema/summary`)
- `server-timeout` (default `180`)
- `worker-timeout` (default `120`)

Net effect: −66 lines of duplicated YAML in `quality.yml`, behaviour unchanged.

Closes #126

## Test plan

- [x] `uv run yamllint` clean on both the workflow and the new action
- [x] `uv run invoke lint` clean
- [ ] CI: `Schema Validation` and `Integration Tests (Infrahub)` jobs still reach the end (readiness wait behaves identically via the shared action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Infrahub stack readiness verification into a reusable GitHub Action, eliminating duplicate logic across workflows and enhancing CI/CD pipeline reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->