### PR TITLE
chore: add read-only Bash allowlist to Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run invoke lint)",
+      "Bash(uv run yamllint *)"
+    ]
+  }
+}

--- a/changelog/129.changed.md
+++ b/changelog/129.changed.md
@@ -1,0 +1,1 @@
+Add a project `.claude/settings.json` with a read-only Bash allowlist (`uv run invoke lint`, `uv run yamllint *`) so routine lint commands no longer prompt for permission.


### PR DESCRIPTION
## Summary

Add `.claude/settings.json` with two read-only `permissions.allow` entries so the most-run lint commands stop triggering permission prompts:

- `Bash(uv run invoke lint)` — exact match (no wildcard, so it can't be chained into arbitrary execution)
- `Bash(uv run yamllint *)` — YAML linting with file args

Derived from a scan of recent session transcripts. Everything else high-frequency was either already auto-allowed by Claude Code (`git status/log/diff`, `gh pr/run view/list`, `cat`, `grep`, `ls`, `find`) or deliberately excluded as mutating / arbitrary-execution (`uv run` blanket, `gh api`, `git add/push`, `invoke format` which rewrites files).

Leaves the existing `.claude/settings.local.json` untouched.

Closes #129

## Test plan

- [x] `check json` pre-commit hook passes (valid JSON)
- [x] No mutating or arbitrary-code-execution patterns added

🤖 Generated with [Claude Code](https://claude.com/claude-code)