### PR TITLE
docs: add Testing Philosophy sections to architecture docs

### DIFF
--- a/changelog/90.changed.md
+++ b/changelog/90.changed.md
@@ -1,0 +1,1 @@
+Add "Testing Philosophy" sections to the backend and workers architecture docs, mapping each component to its test type (unit / golden file / integration) per ADR-0004.

--- a/dev/knowledge/backend/architecture.md
+++ b/dev/knowledge/backend/architecture.md
@@ -60,6 +60,23 @@ All extend `infrahub_sdk.checks.InfrahubCheck`. Registered in `.infrahub.yml`.
 - **`srlinux_bgp.j2`** — Renders BGP configuration in SR Linux JSON-RPC/gNMI format.
 - **`srlinux_interfaces.j2`** — Renders interface configuration in SR Linux JSON format.
 
+## Testing Philosophy
+
+This project follows strict TDD (see [ADR-0004](../../adr/0004-tdd-default-methodology.md)): write a failing test, implement the minimum to pass, then refactor. Every component below has a defined test type that proves it works — tests are written *before* the implementation, never after.
+
+| Component | Test type | What the tests prove |
+|-----------|-----------|----------------------|
+| Data layer (`populate_sot.py`, `seed_data.yml`) | Unit | Seed YAML is valid; upserts are idempotent (re-running does not duplicate objects); dependency ordering is respected. |
+| Schema layer (`load_schemas.py`, schema YAML) | Unit | Schema YAML parses and declares the expected attributes; `SCHEMA_LOAD_ORDER` resolves dependencies before dependents. |
+| Infrahub client (`client.py`, `resource_manager.py`, `models.py`) | Unit (mocked httpx) | Query/mutation payloads are well-formed; pool allocation returns the expected resource; Pydantic models validate inputs/outputs. |
+| Transforms (`srlinux_*_transform.py`) | Unit + golden file | Transform output matches expected SR Linux JSON byte-for-byte for a fixed GraphQL input. |
+| Checks (`*_check.py`) | Unit (mock data) | Each check flags the failure case (orphaned rules, duplicate IPs, missing interface data) and passes clean data. |
+| GraphQL queries (`*.gql`) | Unit | Query shape matches what the consuming transform/check expects. |
+| Config generation (`generate_configs.py`, templates) | Unit + golden file | Rendered Jinja2 output matches the committed golden file for known inputs. |
+| Device I/O (`deploy_configs.py`, `validate_configs.py`) | Integration | Device accepts the config via gNMI and post-deploy state matches intent. |
+
+Unit tests live in `tests/unit/` (no external dependencies, fast), golden files in `tests/golden/`, and integration tests in `tests/integration/` (require containerlab + Infrahub). See [adding-schemas.md](../../guides/backend/adding-schemas.md) for the test-first workflow and [python.md](../../guidelines/python.md) for conventions.
+
 ## Key Dependencies
 
 | Package | Purpose |

--- a/dev/knowledge/workers/architecture.md
+++ b/dev/knowledge/workers/architecture.md
@@ -48,6 +48,19 @@ NetworkChangeWorkflow
   (on failure) -> rollback_config()
 ```
 
+## Testing Philosophy
+
+This project follows strict TDD (see [ADR-0004](../../adr/0004-tdd-default-methodology.md)): a failing test defines the behaviour before any workflow or activity is written. Because workflows orchestrate irreversible device changes, the saga/rollback path is tested with the same rigour as the happy path.
+
+| Component | Test type | What the tests prove |
+|-----------|-----------|----------------------|
+| Workflows (`workflows/`) | Unit (`temporalio.testing.WorkflowEnvironment`) | Activities execute in the correct order; on failure, the workflow triggers compensation (e.g. `rollback_config`); signals and timeouts are handled. Activities are mocked so the test is deterministic and fast. |
+| Activities (`activities/`) | Unit (mocked dependencies) | Each activity honours its input/output contract; Infrahub/gNMI clients are mocked so no real device or API is touched. |
+| Worker registration (`worker.py`) | Unit | All workflows and activities are registered on the `network-changes` task queue. |
+| End-to-end orchestration | Integration | Workflow runs against a real Temporal test server and exercises the full deploy → validate → (rollback) path. |
+
+The saga compensation test is mandatory for any workflow that mutates device state — a workflow is not "done" until its rollback path is proven under a failing activity. Unit tests live in `tests/unit/`, integration tests in `tests/integration/`. See [adding-workflows.md](../../guides/workers/adding-workflows.md) for the test-first workflow.
+
 ## Key Dependencies
 
 | Package | Purpose |


### PR DESCRIPTION
## Why

`dev/knowledge/backend/architecture.md` and `dev/knowledge/workers/architecture.md` documented every component but said nothing about how each is tested, leaving a gap between the architecture docs and the project's TDD methodology (ADR-0004).

Closes #90

## What Changed

Added a **Testing Philosophy** section to both architecture docs:

- **Backend** — a component→test-type table covering the data layer, schema layer, Infrahub client, transforms (unit + golden file), checks, GraphQL queries, config generation, and device I/O (integration), plus where each test kind lives.
- **Workers** — a table mapping workflows (unit via `WorkflowEnvironment`), activities, worker registration, and end-to-end orchestration to their test types, and calling out **mandatory saga/rollback testing** for any workflow that mutates device state.

Both link out to ADR-0004 and the relevant adding-* guides. Docs-only; no code or behaviour change.

## How to Review

Read the two `## Testing Philosophy` sections. Check the component→test-type mapping matches the components already listed in each doc and is consistent with ADR-0004's "Test Types by Component" table.

## How to Test

Docs-only — no runnable tests. Internal relative links resolve within `dev/`.

## Impact & Rollout

- [x] Backward compatible
- [x] No new dependencies
- [x] No config changes required
- [x] No database/schema migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)