### PR TITLE
ci: run unit tests before lint/format stage

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -55,7 +55,10 @@ jobs:
   code-quality:
     name: Code Quality
     runs-on: ubuntu-latest
-    needs: [changes]
+    # Correctness first, aesthetics second (#76): lint/format/typecheck only
+    # run after unit tests pass. Shares the python path-filter with unit-tests,
+    # so the two skip or run together.
+    needs: [changes, unit-tests]
     if: needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v6

--- a/changelog/76.changed.md
+++ b/changelog/76.changed.md
@@ -1,0 +1,1 @@
+CI now runs unit tests before the lint/format/typecheck stage — the Code Quality job depends on Unit Tests, so correctness is verified before aesthetics (#76).


### PR DESCRIPTION
## Why

Epic F (TDD embedding) — correctness first, aesthetics second. The `Code Quality` job (ruff lint + format + mypy) and `Unit Tests` both depended only on the `changes` job, so they ran **in parallel**. Style/typing nits were reported even when the test suite was red.

Closes #76

## What Changed

`code-quality` now declares `needs: [changes, unit-tests]` (was `[changes]`), so the lint/format/typecheck stage only runs after unit tests pass.

Both jobs already share the same `if: needs.changes.outputs.python == 'true'` path-filter condition, so they continue to skip or run together — there's no "skipped dependency silently skips the dependent" trap. If unit tests fail, `code-quality` is skipped and the Quality Gate fails on the unit-test failure as before.

Left unchanged:
- `yaml-lint` — gated on the `yaml` filter (not `python`); chaining it to unit-tests would wrongly skip it on YAML-only PRs.
- `security-scanning` — correctness, not aesthetics; fine to keep parallel.

## How to Review

One dependency edit in `.github/workflows/quality.yml` (the `code-quality` job's `needs:`), plus a comment and changelog fragment.

## How to Test

Observable on this PR: `Code Quality` should start only after `Unit Tests` completes (previously concurrent). yamllint passes locally.

## Impact & Rollout

- [x] Backward compatible
- [x] No new dependencies
- [x] No config changes required
- [x] No database/schema migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)