### PR TITLE
test: backfill unit coverage for worker, workflows, and validation stubs

### DIFF
--- a/changelog/133.added.md
+++ b/changelog/133.added.md
@@ -1,0 +1,1 @@
+Backfill unit tests for NetworkChangeWorkflow, the Temporal worker entry point, the hygiene checker, and the post-deploy validation stubs.

--- a/tests/unit/test_hygiene_checker.py
+++ b/tests/unit/test_hygiene_checker.py
@@ -1,0 +1,132 @@
+"""Unit tests for the pre-deployment hygiene checker.
+
+Covers the BGP and interface JSON validation logic and the combined
+`run_hygiene_checks` entry point, including the failure branches that abort
+a deployment.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from network_synapse.scripts.hygiene_checker import (
+    run_hygiene_checks,
+    validate_bgp_hygiene,
+    validate_interface_hygiene,
+)
+
+# ---------------------------------------------------------------------------
+# Sample payloads
+# ---------------------------------------------------------------------------
+
+
+def _bgp_payload(asn: int = 65000, groups: list | None = None, neighbors: list | None = None) -> str:
+    bgp: dict = {"autonomous-system": asn}
+    bgp["group"] = [{"group-name": "underlay"}] if groups is None else groups
+    bgp["neighbor"] = [{"peer-address": "10.0.0.1"}] if neighbors is None else neighbors
+    return json.dumps({"network-instance": [{"name": "default", "protocols": {"bgp": bgp}}]})
+
+
+def _iface_payload(interfaces: list | None = None) -> str:
+    if interfaces is None:
+        interfaces = [
+            {
+                "name": "ethernet-1/1",
+                "subinterface": [{"ipv4": {"address": [{"ip-prefix": "10.0.0.0/31"}]}}],
+            }
+        ]
+    return json.dumps({"interface": interfaces})
+
+
+# ---------------------------------------------------------------------------
+# validate_bgp_hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBGPHygiene:
+    def test_valid_payload_passes(self) -> None:
+        assert validate_bgp_hygiene(_bgp_payload()) is True
+
+    def test_no_network_instance_is_skipped(self) -> None:
+        """A payload without network-instance is treated as not-relevant (passes)."""
+        assert validate_bgp_hygiene(json.dumps({"interface": []})) is True
+
+    def test_network_instance_without_bgp_is_skipped(self) -> None:
+        payload = json.dumps({"network-instance": [{"name": "default", "protocols": {}}]})
+        assert validate_bgp_hygiene(payload) is True
+
+    def test_missing_asn_fails(self) -> None:
+        payload = json.dumps(
+            {"network-instance": [{"name": "default", "protocols": {"bgp": {"group": [{"group-name": "x"}]}}}]}
+        )
+        assert validate_bgp_hygiene(payload) is False
+
+    def test_zero_asn_fails(self) -> None:
+        assert validate_bgp_hygiene(_bgp_payload(asn=0)) is False
+
+    def test_out_of_range_asn_fails(self) -> None:
+        assert validate_bgp_hygiene(_bgp_payload(asn=5_000_000_000)) is False
+
+    def test_empty_groups_fails(self) -> None:
+        assert validate_bgp_hygiene(_bgp_payload(groups=[])) is False
+
+    def test_invalid_neighbor_ip_fails(self) -> None:
+        assert validate_bgp_hygiene(_bgp_payload(neighbors=[{"peer-address": "not-an-ip"}])) is False
+
+    def test_empty_neighbors_passes(self) -> None:
+        assert validate_bgp_hygiene(_bgp_payload(neighbors=[])) is True
+
+    def test_invalid_json_fails(self) -> None:
+        assert validate_bgp_hygiene("not json {{") is False
+
+
+# ---------------------------------------------------------------------------
+# validate_interface_hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInterfaceHygiene:
+    def test_valid_payload_passes(self) -> None:
+        assert validate_interface_hygiene(_iface_payload()) is True
+
+    def test_no_interface_key_is_skipped(self) -> None:
+        assert validate_interface_hygiene(json.dumps({"network-instance": []})) is True
+
+    def test_system_interface_name_passes(self) -> None:
+        assert validate_interface_hygiene(_iface_payload([{"name": "system0", "subinterface": []}])) is True
+
+    def test_invalid_interface_name_fails(self) -> None:
+        assert validate_interface_hygiene(_iface_payload([{"name": "wan0", "subinterface": []}])) is False
+
+    def test_invalid_ipv4_prefix_fails(self) -> None:
+        interfaces = [
+            {
+                "name": "ethernet-1/1",
+                "subinterface": [{"ipv4": {"address": [{"ip-prefix": "999.0.0.0/31"}]}}],
+            }
+        ]
+        assert validate_interface_hygiene(_iface_payload(interfaces)) is False
+
+    def test_invalid_json_fails(self) -> None:
+        assert validate_interface_hygiene("not json {{") is False
+
+
+# ---------------------------------------------------------------------------
+# run_hygiene_checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunHygieneChecks:
+    def test_both_valid_passes(self) -> None:
+        assert run_hygiene_checks(_bgp_payload(), _iface_payload()) is True
+
+    def test_bad_bgp_fails(self) -> None:
+        assert run_hygiene_checks(_bgp_payload(asn=0), _iface_payload()) is False
+
+    def test_bad_interface_fails(self) -> None:
+        assert run_hygiene_checks(_bgp_payload(), _iface_payload([{"name": "wan0", "subinterface": []}])) is False

--- a/tests/unit/test_network_change_workflow.py
+++ b/tests/unit/test_network_change_workflow.py
@@ -1,0 +1,248 @@
+"""Unit tests for the NetworkChangeWorkflow.
+
+Tests cover:
+- Successful standard change (backup -> generate -> hygiene -> deploy -> validate)
+- Hygiene failure aborts before any deploy (no rollback)
+- Deploy failure triggers rollback
+- Post-deploy validation failure triggers rollback
+
+The workflow runs `generate_*_config` and `run_hygiene_checks` deterministically
+inside the workflow sandbox, so the happy-path mock for `fetch_device_config`
+returns realistic template vars built from the shared `spine01_device_config`
+fixture — this renders valid SR Linux JSON that passes hygiene.
+"""
+
+from __future__ import annotations
+
+import pytest
+from temporalio import activity
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from synapse_workers.workflows.network_change_workflow import NetworkChangeWorkflow
+from tests.conftest import _recorded_rollback_calls, _recorded_status_updates
+
+DEVICE = "spine01"
+IP = "172.20.20.3"
+BACKUP_CONFIG = '{"interface": [{"name": "ethernet-1/1"}]}'
+TASK_QUEUE = "test-network-change"
+
+# Holds the device_data each test wants fetch_device_config to return.
+_FETCH_RESULT: dict[str, dict] = {}
+
+
+# ---------------------------------------------------------------------------
+# Mock activities
+# ---------------------------------------------------------------------------
+
+
+@activity.defn(name="backup_running_config")
+async def mock_backup(device_hostname: str, ip_address: str) -> str:
+    return BACKUP_CONFIG
+
+
+@activity.defn(name="store_backup")
+async def mock_store_backup(device_hostname: str, config: str) -> None:
+    return None
+
+
+@activity.defn(name="fetch_device_config")
+async def mock_fetch_device_config(device_hostname: str) -> dict:
+    return _FETCH_RESULT["data"]
+
+
+@activity.defn(name="deploy_config")
+async def mock_deploy(device_hostname: str, ip_address: str, config_json: str) -> bool:
+    return True
+
+
+@activity.defn(name="deploy_config")
+async def mock_deploy_fail(device_hostname: str, ip_address: str, config_json: str) -> bool:
+    raise ApplicationError("gNMI deploy failed", non_retryable=True)
+
+
+@activity.defn(name="rollback_config")
+async def mock_rollback(device_hostname: str, ip_address: str, backup_config_json: str) -> bool:
+    _recorded_rollback_calls.append((device_hostname, ip_address, backup_config_json))
+    return True
+
+
+@activity.defn(name="validate_bgp")
+async def mock_validate_bgp(device_hostname: str, ip_address: str) -> bool:
+    return True
+
+
+@activity.defn(name="validate_bgp")
+async def mock_validate_bgp_fail(device_hostname: str, ip_address: str) -> bool:
+    raise ApplicationError("BGP not established", non_retryable=True)
+
+
+@activity.defn(name="validate_interfaces")
+async def mock_validate_interfaces(device_hostname: str, ip_address: str, intended_interfaces: list) -> dict:
+    return {"passed": True, "device": device_hostname}
+
+
+@activity.defn(name="update_device_status")
+async def mock_update_status(device_hostname: str, status: str) -> None:
+    _recorded_status_updates.append((device_hostname, status))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_device_data(spine01_device_config) -> dict:
+    """Realistic template vars that render valid, hygiene-passing configs."""
+    iface_vars = spine01_device_config.to_interface_template_vars().model_dump()
+    # The hygiene checker only accepts ethernet-*/system* names, so use the
+    # SR Linux system loopback name instead of the fixture's "loopback0".
+    for iface in iface_vars["interfaces"]:
+        if iface["name"] == "loopback0":
+            iface["name"] = "system0"
+    return {
+        "bgp": spine01_device_config.to_bgp_template_vars().model_dump(),
+        "interfaces": iface_vars,
+    }
+
+
+def _activities(deploy=mock_deploy, validate_bgp=mock_validate_bgp):
+    return [
+        mock_backup,
+        mock_store_backup,
+        mock_fetch_device_config,
+        deploy,
+        mock_rollback,
+        validate_bgp,
+        mock_validate_interfaces,
+        mock_update_status,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_network_change_success(spine01_device_config) -> None:
+    """Happy path: backup -> generate -> hygiene -> deploy -> validate -> active."""
+    _FETCH_RESULT["data"] = _valid_device_data(spine01_device_config)
+
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[NetworkChangeWorkflow],
+            activities=_activities(),
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            # The workflow signals failure with plain RuntimeError; without this
+            # Temporal treats it as a workflow-task bug and retries forever.
+            workflow_failure_exception_types=[RuntimeError],
+        ),
+    ):
+        result = await env.client.execute_workflow(
+            NetworkChangeWorkflow.run,
+            args=[DEVICE, IP],
+            id=f"netchange-success-{DEVICE}",
+            task_queue=TASK_QUEUE,
+        )
+
+    assert result == "SUCCESS"
+    assert (DEVICE, "active") in _recorded_status_updates
+    assert _recorded_rollback_calls == []
+
+
+@pytest.mark.asyncio
+async def test_network_change_hygiene_failure_aborts_without_rollback(spine01_device_config) -> None:
+    """Invalid BGP ASN fails hygiene before deploy — abort, mark maintenance, no rollback."""
+    bad = _valid_device_data(spine01_device_config)
+    bad["bgp"]["local_asn"] = 0  # renders autonomous-system 0 -> hygiene fails
+
+    _FETCH_RESULT["data"] = bad
+
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[NetworkChangeWorkflow],
+            activities=_activities(),
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            # The workflow signals failure with plain RuntimeError; without this
+            # Temporal treats it as a workflow-task bug and retries forever.
+            workflow_failure_exception_types=[RuntimeError],
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                NetworkChangeWorkflow.run,
+                args=[DEVICE, IP],
+                id=f"netchange-hygiene-fail-{DEVICE}",
+                task_queue=TASK_QUEUE,
+            )
+
+    assert "Hygiene" in str(exc_info.value.cause)
+    assert (DEVICE, "maintenance") in _recorded_status_updates
+    assert _recorded_rollback_calls == []
+
+
+@pytest.mark.asyncio
+async def test_network_change_deploy_failure_rolls_back(spine01_device_config) -> None:
+    """Deploy failure triggers rollback and marks maintenance."""
+    _FETCH_RESULT["data"] = _valid_device_data(spine01_device_config)
+
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[NetworkChangeWorkflow],
+            activities=_activities(deploy=mock_deploy_fail),
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            workflow_failure_exception_types=[RuntimeError],
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                NetworkChangeWorkflow.run,
+                args=[DEVICE, IP],
+                id=f"netchange-deploy-fail-{DEVICE}",
+                task_queue=TASK_QUEUE,
+            )
+
+    assert "rolled back" in str(exc_info.value.cause)
+    assert any(call[0] == DEVICE and call[2] == BACKUP_CONFIG for call in _recorded_rollback_calls)
+    assert (DEVICE, "maintenance") in _recorded_status_updates
+
+
+@pytest.mark.asyncio
+async def test_network_change_validation_failure_rolls_back(spine01_device_config) -> None:
+    """Post-deploy validation failure triggers rollback and marks maintenance."""
+    _FETCH_RESULT["data"] = _valid_device_data(spine01_device_config)
+
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[NetworkChangeWorkflow],
+            activities=_activities(validate_bgp=mock_validate_bgp_fail),
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            workflow_failure_exception_types=[RuntimeError],
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                NetworkChangeWorkflow.run,
+                args=[DEVICE, IP],
+                id=f"netchange-validate-fail-{DEVICE}",
+                task_queue=TASK_QUEUE,
+            )
+
+    assert "Validation failed" in str(exc_info.value.cause)
+    assert any(call[0] == DEVICE and call[2] == BACKUP_CONFIG for call in _recorded_rollback_calls)
+    assert (DEVICE, "maintenance") in _recorded_status_updates

--- a/tests/unit/test_validate_configs.py
+++ b/tests/unit/test_validate_configs.py
@@ -1,0 +1,27 @@
+"""Unit tests for the post-deploy validation stubs.
+
+`validate_configs.py` currently holds unimplemented gNMI validation stubs.
+These characterization tests pin the current (no-op) contract so the module
+is covered and any future implementation has a failing-test starting point.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from network_synapse.scripts.validate_configs import (
+    validate_bgp_sessions,
+    validate_interfaces,
+)
+
+
+@pytest.mark.unit
+def test_validate_bgp_sessions_is_callable_stub() -> None:
+    """Stub returns None until gNMI validation is implemented."""
+    assert validate_bgp_sessions("leaf01") is None
+
+
+@pytest.mark.unit
+def test_validate_interfaces_is_callable_stub() -> None:
+    """Stub returns None until gNMI validation is implemented."""
+    assert validate_interfaces("leaf01") is None

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,0 +1,85 @@
+"""Unit tests for the Temporal worker entry point.
+
+`worker.main()` connects to Temporal and registers all workflows and
+activities on the `network-changes` task queue. These tests mock the Temporal
+SDK so we can assert the registration contract without a live server.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from synapse_workers import worker
+from synapse_workers.workflows.drift_remediation_workflow import DriftRemediationWorkflow
+from synapse_workers.workflows.emergency_change_workflow import EmergencyChangeWorkflow
+from synapse_workers.workflows.network_change_workflow import NetworkChangeWorkflow
+
+
+@pytest.mark.asyncio
+async def test_main_connects_with_default_address_and_runs() -> None:
+    """With no env override, connect to localhost:7233 and run the worker."""
+    with (
+        patch.object(worker.Client, "connect", new=AsyncMock()) as mock_connect,
+        patch.object(worker, "Worker") as mock_worker_cls,
+    ):
+        mock_worker_cls.return_value.run = AsyncMock()
+
+        await worker.main()
+
+        mock_connect.assert_awaited_once_with("localhost:7233")
+        mock_worker_cls.return_value.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_main_uses_temporal_address_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TEMPORAL_ADDRESS overrides the default endpoint."""
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "temporal.example.com:7233")
+
+    with (
+        patch.object(worker.Client, "connect", new=AsyncMock()) as mock_connect,
+        patch.object(worker, "Worker") as mock_worker_cls,
+    ):
+        mock_worker_cls.return_value.run = AsyncMock()
+
+        await worker.main()
+
+        mock_connect.assert_awaited_once_with("temporal.example.com:7233")
+
+
+@pytest.mark.asyncio
+async def test_main_registers_all_workflows_and_activities() -> None:
+    """Worker is built on the network-changes queue with every workflow + activity."""
+    with (
+        patch.object(worker.Client, "connect", new=AsyncMock()),
+        patch.object(worker, "Worker") as mock_worker_cls,
+    ):
+        mock_worker_cls.return_value.run = AsyncMock()
+
+        await worker.main()
+
+        _, kwargs = mock_worker_cls.call_args
+        assert kwargs["task_queue"] == "network-changes"
+
+        assert set(kwargs["workflows"]) == {
+            NetworkChangeWorkflow,
+            DriftRemediationWorkflow,
+            EmergencyChangeWorkflow,
+        }
+
+        # All 11 activities registered (names are stable across the codebase).
+        activity_names = {fn.__name__ for fn in kwargs["activities"]}
+        assert activity_names == {
+            "backup_running_config",
+            "store_backup",
+            "fetch_device_config",
+            "fetch_running_config",
+            "update_device_status",
+            "deploy_config",
+            "rollback_config",
+            "validate_bgp",
+            "validate_interfaces",
+            "log_audit_event",
+            "render_intended_config",
+        }


### PR DESCRIPTION
## Summary

Closes #134 (first slice of #95).

Backfills unit tests for four previously untested modules (474 new test lines, no source changes):

- **`test_network_change_workflow.py`** — `NetworkChangeWorkflow` happy path, hygiene-failure abort (no rollback), deploy-failure rollback, and validation-failure rollback, using mocked Temporal activities against a local test server
- **`test_worker.py`** — worker entry point: default/env-var Temporal address and the full workflow + activity registration contract
- **`test_hygiene_checker.py`** — BGP and interface hygiene validation rules
- **`test_validate_configs.py`** — pins the current no-op gNMI validation stubs

## Notes for reviewers

- The workflow tests use `UnsandboxedWorkflowRunner` (same as the existing drift/emergency workflow tests) because `NetworkChangeWorkflow` renders templates and runs hygiene checks inside workflow code, which the Temporal sandbox rejects.
- They also declare `workflow_failure_exception_types=[RuntimeError]` on the test worker: the workflow signals failure with plain `RuntimeError`, which Temporal otherwise treats as a retryable workflow-task error (the tests would hang forever).
- ⚠️ Found while writing these tests: the hygiene checker rejects any interface not named `ethernet-*`/`system*`, but the seed data / fixtures use `loopback0`. The real workflow would abort on hygiene with this data. The happy-path test renames it to `system0`; the naming mismatch probably deserves its own issue.

## Test plan

- [x] `uv run invoke backend.test-unit` — 154 passed
- [x] `uv run invoke lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
