### PR TITLE
fix: accept loopback*/mgmt* interface names in hygiene checker

### DIFF
--- a/backend/network_synapse/scripts/hygiene_checker.py
+++ b/backend/network_synapse/scripts/hygiene_checker.py
@@ -65,7 +65,8 @@ def validate_interface_hygiene(iface_json: str) -> bool:
     """Validate SR Linux Interface JSON payload.
 
     Checks:
-    1. Interfaces have valid names (ethernet-1/* or system0)
+    1. Interfaces have valid names (same convention as the interface
+       consistency check: ethernet-*/system*/loopback*/mgmt*)
     2. Subinterfaces have valid IPv4/IPv6 prefixes
     """
     try:
@@ -76,7 +77,7 @@ def validate_interface_hygiene(iface_json: str) -> bool:
 
         for iface in config.get("interface", []):
             name = iface.get("name", "")
-            if not name.startswith(("ethernet-", "system")):
+            if not name.startswith(("ethernet-", "system", "loopback", "mgmt")):
                 logger.error(f"Hygiene Failed: Invalid interface name format: {name}")
                 return False
 

--- a/changelog/135.fixed.md
+++ b/changelog/135.fixed.md
@@ -1,0 +1,1 @@
+Hygiene checker now accepts `loopback*` and `mgmt*` interface names (matching the interface consistency check convention), so standard changes on devices with loopbacks no longer abort at the pre-deploy hygiene step.

--- a/tests/unit/test_hygiene_checker.py
+++ b/tests/unit/test_hygiene_checker.py
@@ -99,6 +99,14 @@ class TestInterfaceHygiene:
     def test_system_interface_name_passes(self) -> None:
         assert validate_interface_hygiene(_iface_payload([{"name": "system0", "subinterface": []}])) is True
 
+    def test_loopback_interface_name_passes(self) -> None:
+        """loopback0 is the SoT naming used by seed data and transforms (#135)."""
+        assert validate_interface_hygiene(_iface_payload([{"name": "loopback0", "subinterface": []}])) is True
+
+    def test_mgmt_interface_name_passes(self) -> None:
+        """mgmt0 is valid per the interface consistency check naming convention."""
+        assert validate_interface_hygiene(_iface_payload([{"name": "mgmt0", "subinterface": []}])) is True
+
     def test_invalid_interface_name_fails(self) -> None:
         assert validate_interface_hygiene(_iface_payload([{"name": "wan0", "subinterface": []}])) is False
 

--- a/tests/unit/test_network_change_workflow.py
+++ b/tests/unit/test_network_change_workflow.py
@@ -96,15 +96,9 @@ async def mock_update_status(device_hostname: str, status: str) -> None:
 
 def _valid_device_data(spine01_device_config) -> dict:
     """Realistic template vars that render valid, hygiene-passing configs."""
-    iface_vars = spine01_device_config.to_interface_template_vars().model_dump()
-    # The hygiene checker only accepts ethernet-*/system* names, so use the
-    # SR Linux system loopback name instead of the fixture's "loopback0".
-    for iface in iface_vars["interfaces"]:
-        if iface["name"] == "loopback0":
-            iface["name"] = "system0"
     return {
         "bgp": spine01_device_config.to_bgp_template_vars().model_dump(),
-        "interfaces": iface_vars,
+        "interfaces": spine01_device_config.to_interface_template_vars().model_dump(),
     }
 
 


### PR DESCRIPTION
## Summary

Closes #135.

The hygiene checker rejected any interface name not starting with `ethernet-`/`system`, while the seed data, interface schema, and transforms all emit `loopback0`. Net effect: every standard change on a device with a loopback would abort at the pre-deploy hygiene step — the `NetworkChangeWorkflow` happy path was unreachable with real data.

## Fix

- `validate_interface_hygiene()` now accepts `ethernet-*` / `system*` / `loopback*` / `mgmt*` — the same convention `interface_consistency_check.py` already enforces, so naming rules now agree across the codebase.
- TDD: added failing tests for `loopback0` and `mgmt0` first, then the one-line fix.
- Removed the `system0` rename workaround from `_valid_device_data()` in the workflow test — the fixture's real `loopback0` data now passes hygiene end-to-end.

## Test plan

- [x] `uv run invoke backend.test-unit` — 156 passed
- [x] `uv run invoke lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)