### PR TITLE
ci: enforce 80% unit-test coverage gate

### DIFF
--- a/changelog/78.changed.md
+++ b/changelog/78.changed.md
@@ -1,0 +1,1 @@
+Enforce a minimum 80% unit-test coverage gate (`fail_under = 80` in the coverage config) — applies to CI and local `invoke backend.test-unit` runs alike.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 skip_empty = true
+fail_under = 80
 exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.",


### PR DESCRIPTION
## Summary

Adds `fail_under = 80` to `[tool.coverage.report]` in pyproject.toml, so any pytest-cov run — the CI unit-test job, `invoke backend.test-unit`, and `backend.test-all` — fails when coverage drops below 80%.

Configured in the coverage config rather than as a `--cov-fail-under` CLI flag so there is a single source of truth shared by CI and local runs.

## Context

The #95 backfill epic (PRs #133, #138, #142) brought combined backend + workers coverage to **81%**, so the gate lands with a ~1-point buffer. Largest remaining headroom if the buffer ever gets tight: `populate_sot.py` (52%), `load_schemas.py` (65%), `resource_manager.py` (75%).

## Test plan

- [x] Deliberately partial run (`pytest tests/unit/test_worker.py --cov=...`) exits 1 with `FAIL Required test coverage of 80.0% not reached. Total coverage: 15.23%`
- [x] Full unit suite with CI's exact coverage scope passes at 81% (exit 0)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)