### PR TITLE
feat: add temporal-developer agent skill as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "library/schema-library"]
 	path = library/schema-library
 	url = https://github.com/opsmill/schema-library.git
+[submodule "dev/skills/temporal-developer"]
+	path = dev/skills/temporal-developer
+	url = https://github.com/temporalio/skill-temporal-developer.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ AI agent skills are loaded automatically from `dev/skills/` (symlinked to `.clau
 | **srlinux-gnmi** | `dev/skills/srlinux-gnmi/SKILL.md` | YANG-modelled JSON config (NOT CLI), gNMI SET/GET via pygnmi, interface naming, lab topology |
 | **intent-model** | `dev/skills/intent-model/SKILL.md` | 5-object business intent chain, 3-object operational intent, forward/reverse lineage, override-aware drift |
 | **containerlab** | `dev/skills/containerlab/SKILL.md` | Topology YAML, SR Linux images, OrbStack networking, lab lifecycle, DNS names |
-| **temporal-developer** | `dev/skills/temporal-developer/` (git submodule, planned) | Workflow determinism, activity patterns, retry policies, testing, worker config |
+| **temporal-developer** | `dev/skills/temporal-developer/SKILL.md` (git submodule: [temporalio/skill-temporal-developer](https://github.com/temporalio/skill-temporal-developer)) | Workflow determinism, activity patterns, retry policies, testing, worker config — all Temporal SDKs |
 
 ### Skill Interaction Map
 

--- a/changelog/96.added.md
+++ b/changelog/96.added.md
@@ -1,0 +1,1 @@
+Add the official [temporalio/skill-temporal-developer](https://github.com/temporalio/skill-temporal-developer) agent skill as a git submodule at `dev/skills/temporal-developer/`, exposed to Claude via the existing `.claude/skills` symlink.


### PR DESCRIPTION
## Summary

Adds the official [temporalio/skill-temporal-developer](https://github.com/temporalio/skill-temporal-developer) repository as a git submodule at `dev/skills/temporal-developer/`, following the same pattern as the existing `library/schema-library` submodule.

## Notes

- **No per-skill symlink needed**: `.claude/skills` is already a symlink to `dev/skills`, so the skill registers with Claude Code automatically once the submodule is initialized (verified locally — the skill loaded and is invocable).
- Updates the AGENTS.md skill inventory entry from "(git submodule, planned)" to the live submodule, and notes the skill covers all Temporal SDKs.
- Pinned to upstream `main` (v0.5.0 of the skill). Update with `git submodule update --remote dev/skills/temporal-developer`.
- No test file: this adds no Python source, schema, or workflow — just a docs/skill submodule.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)