### PR TITLE
feat: add golden file testing framework for Jinja2 templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
+        exclude: ^tests/golden/  # golden files are byte-exact template output
       - id: check-ast
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -17,6 +18,7 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=500]
       - id: end-of-file-fixer
+        exclude: ^tests/golden/  # golden files are byte-exact template output
       - id: no-commit-to-branch
         args: [--branch, main]
 

--- a/changelog/93.added.md
+++ b/changelog/93.added.md
@@ -1,0 +1,1 @@
+Golden file testing framework for the SR Linux Jinja2 templates: rendered output is compared byte-for-byte against `tests/golden/*.json`, with `pytest --update-golden` to deliberately regenerate after intentional template changes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Shared test fixtures for the network automation project."""
 
+import difflib
 import os
+from pathlib import Path
 
 import pytest
 
@@ -39,6 +41,84 @@ def _reset_workflow_spies() -> None:
     _recorded_audit_events.clear()
     _recorded_store_backup_calls.clear()
     _recorded_rollback_calls.clear()
+
+
+# ---------------------------------------------------------------------------
+# Golden file testing (Issue #93)
+# ---------------------------------------------------------------------------
+# Rendered template output is compared byte-for-byte against a stored golden
+# file in tests/golden/. Template changes fail the comparison until the golden
+# files are deliberately regenerated with `pytest --update-golden`, so every
+# output change is reviewed in the PR diff.
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--update-golden",
+        action="store_true",
+        default=False,
+        help="Regenerate golden files from current template output instead of comparing.",
+    )
+
+
+class GoldenFile:
+    """Byte-for-byte comparison of rendered output against a golden file."""
+
+    def __init__(self, golden_dir: Path, update: bool) -> None:
+        self.golden_dir = golden_dir
+        self.update = update
+
+    def assert_match(self, rendered: str, golden_name: str) -> None:
+        """Compare rendered text against tests/golden/<golden_name>.
+
+        In update mode (--update-golden), write the rendered output to the
+        golden file instead and pass.
+        """
+        golden_path = self.golden_dir / golden_name
+
+        if self.update:
+            self.golden_dir.mkdir(parents=True, exist_ok=True)
+            golden_path.write_text(rendered)
+            return
+
+        if not golden_path.exists():
+            raise AssertionError(
+                f"Golden file {golden_path} does not exist. Generate it with: uv run pytest --update-golden"
+            )
+
+        expected = golden_path.read_text()
+        if rendered != expected:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    expected.splitlines(),
+                    rendered.splitlines(),
+                    fromfile=f"golden/{golden_name}",
+                    tofile="rendered",
+                    lineterm="",
+                )
+            )
+            raise AssertionError(
+                f"Rendered output does not match golden file {golden_path}.\n"
+                f"If this change is intentional, regenerate with: uv run pytest --update-golden\n\n{diff}"
+            )
+
+
+@pytest.fixture
+def golden(request: pytest.FixtureRequest) -> GoldenFile:
+    """Golden file helper bound to tests/golden/, honouring --update-golden."""
+    return GoldenFile(GOLDEN_DIR, update=request.config.getoption("--update-golden"))
+
+
+@pytest.fixture
+def make_golden(tmp_path: Path):
+    """Factory for GoldenFile helpers bound to a temp dir (framework self-tests)."""
+
+    def _make(update: bool) -> GoldenFile:
+        return GoldenFile(tmp_path, update=update)
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/golden/srlinux_bgp.json
+++ b/tests/golden/srlinux_bgp.json
@@ -1,0 +1,39 @@
+
+
+{
+    "network-instance": [
+        {
+            "name": "default",
+            "protocols": {
+                "bgp": {
+                    "autonomous-system": 65000,
+                    "router-id": "192.0.2.1",
+                    "group": [
+                        {
+                            "group-name": "underlay",
+                            "export-policy": "export-all",
+                            "import-policy": "import-all"
+                        }
+                    ],
+                    "neighbor": [
+
+                        {
+                            "peer-address": "10.0.0.1",
+                            "peer-as": 65001,
+                            "peer-group": "underlay",
+                            "description": "spine01 to leaf01"
+                        },
+
+                        {
+                            "peer-address": "10.0.0.3",
+                            "peer-as": 65002,
+                            "peer-group": "underlay",
+                            "description": ""
+                        }
+
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/golden/srlinux_interfaces.json
+++ b/tests/golden/srlinux_interfaces.json
@@ -1,0 +1,67 @@
+
+
+{
+    "interface": [
+
+        {
+            "name": "ethernet-1/1",
+            "description": "spine01 to leaf01",
+            "admin-state": "enable",
+            "mtu": 9100,
+            "subinterface": [
+                {
+                    "index": 0,
+
+                    "ipv4": {
+                        "admin-state": "enable",
+                        "address": [
+                            {
+                                "ip-prefix": "10.0.0.0/31"
+                            }
+                        ]
+                    },
+
+                    "description": "spine01 to leaf01"
+                }
+            ]
+        },
+
+        {
+            "name": "ethernet-1/2",
+            "description": "",
+            "admin-state": "disable",
+            "mtu": 9214,
+            "subinterface": [
+                {
+                    "index": 0,
+
+                    "description": ""
+                }
+            ]
+        },
+
+        {
+            "name": "loopback0",
+            "description": "router-id loopback",
+            "admin-state": "enable",
+            "mtu": 9214,
+            "subinterface": [
+                {
+                    "index": 0,
+
+                    "ipv4": {
+                        "admin-state": "enable",
+                        "address": [
+                            {
+                                "ip-prefix": "192.0.2.1/32"
+                            }
+                        ]
+                    },
+
+                    "description": "router-id loopback"
+                }
+            ]
+        }
+
+    ]
+}

--- a/tests/unit/test_golden_templates.py
+++ b/tests/unit/test_golden_templates.py
@@ -1,0 +1,130 @@
+"""Golden file tests for the SR Linux Jinja2 templates (Issue #93).
+
+Each template is rendered with known, deterministic inputs and compared
+byte-for-byte against a golden file in tests/golden/. Any template change
+fails these tests until the golden file is deliberately regenerated with:
+
+    uv run pytest tests/unit/test_golden_templates.py --update-golden
+
+Regenerated golden files show up in the PR diff for review.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from network_synapse.scripts.generate_configs import generate_bgp_config, generate_interface_config
+
+
+@pytest.fixture
+def golden_interface_inputs() -> dict:
+    """Deterministic interface data exercising every template branch.
+
+    - ethernet-1/1: routed interface with IP, explicit MTU and description
+    - ethernet-1/2: disabled, no IP, all defaults (mtu, subinterface index)
+    - loopback0: enabled with IP, default MTU
+    """
+    return {
+        "interfaces": [
+            {
+                "name": "ethernet-1/1",
+                "description": "spine01 to leaf01",
+                "enabled": True,
+                "mtu": 9100,
+                "ip_address": "10.0.0.0/31",
+                "subinterface_index": 0,
+            },
+            {
+                "name": "ethernet-1/2",
+                "enabled": False,
+            },
+            {
+                "name": "loopback0",
+                "description": "router-id loopback",
+                "enabled": True,
+                "ip_address": "192.0.2.1/32",
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def golden_bgp_inputs() -> dict:
+    """Deterministic BGP data exercising defaults and multi-neighbor rendering.
+
+    - session to leaf01: all fields explicit
+    - session to leaf02: group and description omitted (template defaults)
+    """
+    return {
+        "local_asn": 65000,
+        "router_id": "192.0.2.1",
+        "bgp_sessions": [
+            {
+                "remote_ip": "10.0.0.1",
+                "remote_asn": 65001,
+                "group": "underlay",
+                "description": "spine01 to leaf01",
+            },
+            {
+                "remote_ip": "10.0.0.3",
+                "remote_asn": 65002,
+            },
+        ],
+    }
+
+
+@pytest.mark.unit
+class TestGoldenTemplates:
+    def test_interfaces_template_matches_golden(self, golden, golden_interface_inputs) -> None:
+        rendered = generate_interface_config(golden_interface_inputs)
+        golden.assert_match(rendered, "srlinux_interfaces.json")
+
+    def test_bgp_template_matches_golden(self, golden, golden_bgp_inputs) -> None:
+        rendered = generate_bgp_config(golden_bgp_inputs)
+        golden.assert_match(rendered, "srlinux_bgp.json")
+
+    def test_interfaces_golden_output_is_valid_json(self, golden_interface_inputs) -> None:
+        """The golden inputs must render to parseable JSON (gNMI SET payload)."""
+        parsed = json.loads(generate_interface_config(golden_interface_inputs))
+        assert [i["name"] for i in parsed["interface"]] == ["ethernet-1/1", "ethernet-1/2", "loopback0"]
+
+    def test_bgp_golden_output_is_valid_json(self, golden_bgp_inputs) -> None:
+        """The golden inputs must render to parseable JSON (gNMI SET payload)."""
+        parsed = json.loads(generate_bgp_config(golden_bgp_inputs))
+        bgp = parsed["network-instance"][0]["protocols"]["bgp"]
+        assert bgp["autonomous-system"] == 65000
+        assert len(bgp["neighbor"]) == 2
+
+
+@pytest.mark.unit
+class TestGoldenFramework:
+    """Behaviour of the golden-file comparison helper itself."""
+
+    def test_missing_golden_file_fails_with_update_hint(self, make_golden) -> None:
+        helper = make_golden(update=False)
+        with pytest.raises(AssertionError, match="--update-golden"):
+            helper.assert_match("content", "does_not_exist.json")
+
+    def test_mismatch_fails_with_diff(self, make_golden) -> None:
+        helper = make_golden(update=False)
+        (helper.golden_dir / "sample.json").write_text("old content\n")
+        with pytest.raises(AssertionError, match=r"-old content|\+new content"):
+            helper.assert_match("new content\n", "sample.json")
+
+    def test_match_passes(self, make_golden) -> None:
+        helper = make_golden(update=False)
+        (helper.golden_dir / "sample.json").write_text("same content\n")
+        helper.assert_match("same content\n", "sample.json")
+
+    def test_update_mode_writes_golden_file(self, make_golden) -> None:
+        helper = make_golden(update=True)
+        helper.assert_match("fresh content\n", "sample.json")
+        assert (helper.golden_dir / "sample.json").read_text() == "fresh content\n"
+
+    def test_update_mode_overwrites_stale_golden_file(self, make_golden) -> None:
+        helper = make_golden(update=True)
+        (helper.golden_dir / "sample.json").write_text("stale\n")
+        helper.assert_match("fresh\n", "sample.json")
+        assert (helper.golden_dir / "sample.json").read_text() == "fresh\n"


### PR DESCRIPTION
## Summary

Implements golden file testing for the SR Linux Jinja2 templates (Epic F: TDD Embedding). Rendered template output is compared **byte-for-byte** against stored golden files in `tests/golden/`, so any template change fails CI until the golden files are deliberately regenerated — and the regenerated files show up in the PR diff for review.

## How it works

- `GoldenFile` helper + `golden` fixture in `tests/conftest.py`
- New pytest flag: `uv run pytest --update-golden` regenerates golden files from current output
- Mismatch failures print a unified diff plus the regenerate command
- Missing golden files fail with the same hint (no silent auto-creation in normal runs)

## Golden files

- `tests/golden/srlinux_interfaces.json` — inputs cover every branch: routed interface with IP + explicit MTU, disabled interface with all defaults, loopback
- `tests/golden/srlinux_bgp.json` — multi-neighbor with explicit fields and template defaults

## Notes

- `tests/golden/` is excluded from the `trailing-whitespace` / `end-of-file-fixer` pre-commit hooks: Jinja output has no trailing newline, and the fixers would rewrite the byte-exact files and break the comparison.
- Framework behaviour itself is unit-tested (missing golden, mismatch diff, update/overwrite modes) via a `tmp_path`-bound factory.
- TDD order: test file written first (red on missing fixture, then red on missing goldens), framework implemented, goldens generated with `--update-golden` (green).

## Test plan

- [x] `uv run pytest tests/unit/test_golden_templates.py` — 9 passed
- [x] Full unit suite: 271 passed, coverage 81.78% (gate: 80%)
- [x] `uv run invoke lint` clean

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)