### PR TITLE
feat: add alert rules for the 8 Epic E alert conditions

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -17,5 +17,6 @@ ignore: |
   .git/
   .venv/
   library/
+  dev/skills/temporal-developer/
   node_modules/
   *.lock

--- a/changelog/80.added.md
+++ b/changelog/80.added.md
@@ -1,0 +1,1 @@
+Prometheus alert rules for the 8 Epic E alert conditions (PlatformDown, WorkerSaturation, OverrideRevertFailed, OrphanedRulesIncreasing, DriftScoreElevated, LineageCoverageDrop, SuzieQStale, HighSupportTicketRate), with unit tests validating names, severities, and rule structure.

--- a/development/prometheus/alert_rules.yml
+++ b/development/prometheus/alert_rules.yml
@@ -76,3 +76,125 @@ groups:
           description: >-
             The Infrahub source-of-truth API has been unreachable for more
             than 2 minutes. Configuration generation workflows will fail.
+
+  # ---------------------------------------------------------------------------
+  # Epic E alert conditions (Issue #80)
+  # ---------------------------------------------------------------------------
+  # Severity routing is handled by alertmanager.yml (critical -> immediate
+  # Slack, warning -> batched, info -> default channel).
+  #
+  # Metric sources:
+  #   up{}                                  -- Prometheus scrape health (prometheus.yml)
+  #   temporal_worker_task_slots_available  -- Temporal SDK worker metrics
+  #   override_revert_failures_total        -- override revert activity counter
+  #   orphaned_rules_total                  -- hygiene checker / posture writer (#70)
+  #   drift_score                           -- SuzieQ custom exporter (#74)
+  #   lineage_coverage_ratio                -- compliance posture writer (#70)
+  #   suzieq_last_poll_timestamp_seconds    -- SuzieQ custom exporter (#74)
+  #   support_tickets_opened_total          -- Golden Path adoption metrics (#77)
+
+  - name: platform_health
+    rules:
+      - alert: PlatformDown
+        expr: up{job=~"infrahub|temporal"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} is down"
+          description: >-
+            Prometheus has been unable to scrape {{ $labels.job }}
+            ({{ $labels.instance }}) for 2 minutes. The automation platform
+            cannot function without it. See docs/runbooks.md.
+
+      - alert: WorkerSaturation
+        expr: temporal_worker_task_slots_available{worker_type="WorkflowWorker"} == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Temporal worker has no free workflow task slots"
+          description: >-
+            The Temporal worker on task queue {{ $labels.task_queue }} has had
+            zero available workflow task slots for 5 minutes. Workflow starts
+            are queueing; consider scaling workers or investigating stuck
+            workflows.
+
+  - name: intent_compliance
+    rules:
+      - alert: OverrideRevertFailed
+        expr: increase(override_revert_failures_total[15m]) > 0
+        for: 0s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Operational override revert failed on {{ $labels.device }}"
+          description: >-
+            An override revert failed in the last 15 minutes. The device may
+            be running non-intended config indefinitely. Manual intervention
+            required — see docs/runbooks.md.
+
+      - alert: OrphanedRulesIncreasing
+        expr: delta(orphaned_rules_total[1h]) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Orphaned rule count is increasing"
+          description: >-
+            The number of deployed config rules with no owning intent has been
+            rising for the last hour ({{ $value }} new orphans). Run the
+            hygiene checker to identify and reap them.
+
+      - alert: DriftScoreElevated
+        expr: drift_score > 0.2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Config drift elevated on {{ $labels.device }}"
+          description: >-
+            Drift score for {{ $labels.device }} has exceeded 0.2 for
+            10 minutes (current: {{ $value }}). Running config is diverging
+            from Infrahub intended state; drift remediation may be failing or
+            overrides may be accumulating.
+
+      - alert: LineageCoverageDrop
+        expr: lineage_coverage_ratio < 0.95
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Intent lineage coverage below 95%"
+          description: >-
+            Less than 95% of deployed config traces back to a business or
+            operational intent (current: {{ $value | humanizePercentage }}).
+            New unmanaged config may have been applied outside the platform.
+
+  - name: telemetry_health
+    rules:
+      - alert: SuzieQStale
+        expr: time() - suzieq_last_poll_timestamp_seconds > 900
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SuzieQ poller data is stale"
+          description: >-
+            SuzieQ has not completed a successful device poll in over
+            15 minutes. Drift detection and state validation are operating
+            on stale data.
+
+  - name: adoption
+    rules:
+      - alert: HighSupportTicketRate
+        expr: rate(support_tickets_opened_total[1d]) * 86400 > 5
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: "Support ticket rate above 5/day"
+          description: >-
+            More than 5 network-automation support tickets per day over the
+            last 24 hours. The Golden Path may have a usability gap — review
+            recent tickets for common themes.

--- a/tests/unit/test_alert_rules.py
+++ b/tests/unit/test_alert_rules.py
@@ -1,0 +1,103 @@
+"""Unit tests for the Prometheus alert rules file (Issue #80).
+
+Validates development/prometheus/alert_rules.yml against the alert
+specification from Epic E: all 8 alert conditions present, correct
+severities, and well-formed rule structure (expr, labels, annotations).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ALERT_RULES_PATH = Path(__file__).parents[2] / "development" / "prometheus" / "alert_rules.yml"
+
+# Alert name -> required severity, per Issue #80
+EXPECTED_ALERTS = {
+    "PlatformDown": "critical",
+    "WorkerSaturation": "warning",
+    "OverrideRevertFailed": "critical",
+    "OrphanedRulesIncreasing": "warning",
+    "DriftScoreElevated": "warning",
+    "LineageCoverageDrop": "warning",
+    "SuzieQStale": "warning",
+    "HighSupportTicketRate": "info",
+}
+
+
+@pytest.fixture(scope="module")
+def alert_rules() -> dict:
+    """Parsed alert_rules.yml content."""
+    assert ALERT_RULES_PATH.exists(), f"{ALERT_RULES_PATH} does not exist"
+    return yaml.safe_load(ALERT_RULES_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def rules_by_name(alert_rules: dict) -> dict[str, dict]:
+    """All alerting rules across groups, keyed by alert name."""
+    rules = {}
+    for group in alert_rules.get("groups", []):
+        for rule in group.get("rules", []):
+            if "alert" in rule:
+                rules[rule["alert"]] = rule
+    return rules
+
+
+@pytest.mark.unit
+class TestAlertRulesFile:
+    def test_file_has_at_least_one_group(self, alert_rules: dict) -> None:
+        groups = alert_rules.get("groups")
+        assert isinstance(groups, list)
+        assert len(groups) >= 1
+
+    def test_every_group_has_name_and_rules(self, alert_rules: dict) -> None:
+        for group in alert_rules["groups"]:
+            assert group.get("name"), f"group missing name: {group}"
+            assert isinstance(group.get("rules"), list)
+            assert len(group["rules"]) >= 1
+
+
+@pytest.mark.unit
+class TestAlertConditions:
+    def test_all_eight_alerts_present(self, rules_by_name: dict) -> None:
+        """The 8 Epic E alerts must exist alongside the pre-existing device alerts."""
+        missing = set(EXPECTED_ALERTS) - set(rules_by_name)
+        assert not missing, f"missing alerts: {sorted(missing)}"
+
+    def test_every_rule_in_file_is_well_formed(self, rules_by_name: dict) -> None:
+        """All rules (including pre-existing ones) have expr, valid severity, and annotations."""
+        for name, rule in rules_by_name.items():
+            assert str(rule.get("expr", "")).strip(), f"{name}: empty expr"
+            assert rule.get("labels", {}).get("severity") in ("critical", "warning", "info"), (
+                f"{name}: invalid severity"
+            )
+            assert rule.get("annotations", {}).get("summary"), f"{name}: missing summary"
+
+    @pytest.mark.parametrize(("alert_name", "severity"), sorted(EXPECTED_ALERTS.items()))
+    def test_alert_has_expected_severity(self, rules_by_name: dict, alert_name: str, severity: str) -> None:
+        rule = rules_by_name[alert_name]
+        assert rule.get("labels", {}).get("severity") == severity
+
+    @pytest.mark.parametrize("alert_name", sorted(EXPECTED_ALERTS))
+    def test_alert_has_nonempty_expr(self, rules_by_name: dict, alert_name: str) -> None:
+        expr = rules_by_name[alert_name].get("expr")
+        assert isinstance(expr, str)
+        assert expr.strip()
+
+    @pytest.mark.parametrize("alert_name", sorted(EXPECTED_ALERTS))
+    def test_alert_has_summary_and_description(self, rules_by_name: dict, alert_name: str) -> None:
+        annotations = rules_by_name[alert_name].get("annotations", {})
+        assert annotations.get("summary"), f"{alert_name} missing annotations.summary"
+        assert annotations.get("description"), f"{alert_name} missing annotations.description"
+
+    def test_critical_alerts_fire_quickly(self, rules_by_name: dict) -> None:
+        """Critical alerts must not sit in pending state longer than 5 minutes."""
+        for name, severity in EXPECTED_ALERTS.items():
+            if severity != "critical":
+                continue
+            for_duration = rules_by_name[name].get("for", "0s")
+            value, unit = int(for_duration[:-1]), for_duration[-1]
+            assert unit in ("s", "m"), f"{name}: unexpected 'for' unit {unit}"
+            assert (value if unit == "s" else value * 60) <= 300, f"{name}: 'for' too slow for critical"


### PR DESCRIPTION
## Summary

Extends `development/prometheus/alert_rules.yml` with the 8 alert conditions from Epic E (Issue #80), in four new rule groups. The five pre-existing device alerts (BGP, reachability, flapping, workflow failure rate, Infrahub API) are unchanged.

| Alert | Severity | Group | Fires when |
|---|---|---|---|
| PlatformDown | critical | platform_health | Infrahub or Temporal unscrapeable for 2m |
| WorkerSaturation | warning | platform_health | Zero free workflow task slots for 5m |
| OverrideRevertFailed | critical | intent_compliance | Any revert failure in the last 15m |
| OrphanedRulesIncreasing | warning | intent_compliance | Orphan count rising over 1h |
| DriftScoreElevated | warning | intent_compliance | drift_score > 0.2 for 10m |
| LineageCoverageDrop | warning | intent_compliance | Coverage < 95% for 15m |
| SuzieQStale | warning | telemetry_health | No successful poll in 15m |
| HighSupportTicketRate | info | adoption | > 5 tickets/day |

## Notes

- **Metric names anticipate planned exporters**: `drift_score` / `suzieq_last_poll_timestamp_seconds` (#74), `orphaned_rules_total` / `lineage_coverage_ratio` (#70), `support_tickets_opened_total` (#77). Sources are documented in the file header so the exporters have a contract to implement against.
- Severity routing already exists in `alertmanager.yml` (critical → immediate Slack, warning → batched, info → default channel).
- `dev/skills/temporal-developer/` (submodule from #145) is excluded from yamllint: its upstream workflow files exceed our 120-char limit and would fail the CI YAML Lint job on any PR touching YAML — this one included.

## Test plan

- [x] TDD: `tests/unit/test_alert_rules.py` written first (red), rules added (green) — 29 tests covering presence, severities, rule structure, and critical-alert latency
- [x] `promtool check rules` (via prom/prometheus docker image): 13 rules, SUCCESS
- [x] Full unit suite: 300 passed, coverage gate met
- [x] `uv run invoke lint` + `docs.lint-yaml` clean on tracked files

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new alerting rules to improve visibility into platform health, telemetry, adoption, compliance, and support ticket trends.

* **Bug Fixes**
  * Expanded linting exclusions to cover an additional development directory.

* **Tests**
  * Added automated checks to validate the alert rules file structure, required fields, severities, and timing thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->