### PR TITLE
fix: address CodeRabbit review feedback on PR #147 alert rules

### DIFF
--- a/changelog/80.fixed.md
+++ b/changelog/80.fixed.md
@@ -1,0 +1,1 @@
+Correct the WorkerSaturation alert description (the Temporal worker metric has no `task_queue` label) and the SuzieQStale firing window (20 minutes, not 15); tighten alert-rule test structure per review feedback.

--- a/development/prometheus/alert_rules.yml
+++ b/development/prometheus/alert_rules.yml
@@ -115,8 +115,8 @@ groups:
         annotations:
           summary: "Temporal worker has no free workflow task slots"
           description: >-
-            The Temporal worker on task queue {{ $labels.task_queue }} has had
-            zero available workflow task slots for 5 minutes. Workflow starts
+            The Temporal worker ({{ $labels.instance }}) has had zero
+            available workflow task slots for 5 minutes. Workflow starts
             are queueing; consider scaling workers or investigating stuck
             workflows.
 
@@ -182,7 +182,8 @@ groups:
           summary: "SuzieQ poller data is stale"
           description: >-
             SuzieQ has not completed a successful device poll in over
-            15 minutes. Drift detection and state validation are operating
+            20 minutes (15-minute staleness threshold plus 5 minutes
+            pending). Drift detection and state validation are operating
             on stale data.
 
   - name: adoption

--- a/tests/unit/test_alert_rules.py
+++ b/tests/unit/test_alert_rules.py
@@ -7,6 +7,7 @@ severities, and well-formed rule structure (expr, labels, annotations).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -45,14 +46,27 @@ def rules_by_name(alert_rules: dict) -> dict[str, dict]:
     return rules
 
 
+def _parse_duration_seconds(duration: str) -> int:
+    """Parse a Prometheus duration string (e.g. '30s', '5m', '1h30m') into seconds."""
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    parts = re.findall(r"(\d+)([smhd])", duration)
+    assert parts, f"unparseable duration: {duration!r}"
+    assert "".join(f"{v}{u}" for v, u in parts) == duration, f"unparseable duration: {duration!r}"
+    return sum(int(value) * units[unit] for value, unit in parts)
+
+
 @pytest.mark.unit
 class TestAlertRulesFile:
+    """Structural checks on the alert_rules.yml top-level shape."""
+
     def test_file_has_at_least_one_group(self, alert_rules: dict) -> None:
+        """The file must define a non-empty top-level groups list."""
         groups = alert_rules.get("groups")
         assert isinstance(groups, list)
         assert len(groups) >= 1
 
     def test_every_group_has_name_and_rules(self, alert_rules: dict) -> None:
+        """Each group must be named and contain at least one rule."""
         for group in alert_rules["groups"]:
             assert group.get("name"), f"group missing name: {group}"
             assert isinstance(group.get("rules"), list)
@@ -61,33 +75,29 @@ class TestAlertRulesFile:
 
 @pytest.mark.unit
 class TestAlertConditions:
+    """The 8 Epic E alert conditions from Issue #80."""
+
     def test_all_eight_alerts_present(self, rules_by_name: dict) -> None:
         """The 8 Epic E alerts must exist alongside the pre-existing device alerts."""
         missing = set(EXPECTED_ALERTS) - set(rules_by_name)
         assert not missing, f"missing alerts: {sorted(missing)}"
 
-    def test_every_rule_in_file_is_well_formed(self, rules_by_name: dict) -> None:
-        """All rules (including pre-existing ones) have expr, valid severity, and annotations."""
-        for name, rule in rules_by_name.items():
-            assert str(rule.get("expr", "")).strip(), f"{name}: empty expr"
-            assert rule.get("labels", {}).get("severity") in ("critical", "warning", "info"), (
-                f"{name}: invalid severity"
-            )
-            assert rule.get("annotations", {}).get("summary"), f"{name}: missing summary"
-
     @pytest.mark.parametrize(("alert_name", "severity"), sorted(EXPECTED_ALERTS.items()))
     def test_alert_has_expected_severity(self, rules_by_name: dict, alert_name: str, severity: str) -> None:
+        """Each Epic E alert carries the severity mandated by the issue spec."""
         rule = rules_by_name[alert_name]
         assert rule.get("labels", {}).get("severity") == severity
 
     @pytest.mark.parametrize("alert_name", sorted(EXPECTED_ALERTS))
     def test_alert_has_nonempty_expr(self, rules_by_name: dict, alert_name: str) -> None:
+        """Each Epic E alert has a non-empty PromQL expression."""
         expr = rules_by_name[alert_name].get("expr")
         assert isinstance(expr, str)
         assert expr.strip()
 
     @pytest.mark.parametrize("alert_name", sorted(EXPECTED_ALERTS))
     def test_alert_has_summary_and_description(self, rules_by_name: dict, alert_name: str) -> None:
+        """Each Epic E alert has summary and description annotations."""
         annotations = rules_by_name[alert_name].get("annotations", {})
         assert annotations.get("summary"), f"{alert_name} missing annotations.summary"
         assert annotations.get("description"), f"{alert_name} missing annotations.description"
@@ -97,7 +107,27 @@ class TestAlertConditions:
         for name, severity in EXPECTED_ALERTS.items():
             if severity != "critical":
                 continue
-            for_duration = rules_by_name[name].get("for", "0s")
-            value, unit = int(for_duration[:-1]), for_duration[-1]
-            assert unit in ("s", "m"), f"{name}: unexpected 'for' unit {unit}"
-            assert (value if unit == "s" else value * 60) <= 300, f"{name}: 'for' too slow for critical"
+            for_seconds = _parse_duration_seconds(rules_by_name[name].get("for", "0s"))
+            assert for_seconds <= 300, f"{name}: 'for' too slow for critical"
+
+
+@pytest.mark.unit
+class TestAllRulesWellFormed:
+    """Baseline hygiene for every rule in the file, including pre-existing device alerts."""
+
+    def test_every_rule_has_nonempty_expr(self, rules_by_name: dict) -> None:
+        """No rule may have an empty PromQL expression."""
+        for name, rule in rules_by_name.items():
+            assert str(rule.get("expr", "")).strip(), f"{name}: empty expr"
+
+    def test_every_rule_has_valid_severity(self, rules_by_name: dict) -> None:
+        """Every rule's severity must be one alertmanager.yml routes on."""
+        for name, rule in rules_by_name.items():
+            assert rule.get("labels", {}).get("severity") in ("critical", "warning", "info"), (
+                f"{name}: invalid severity"
+            )
+
+    def test_every_rule_has_summary(self, rules_by_name: dict) -> None:
+        """Every rule must carry a summary annotation for Slack notifications."""
+        for name, rule in rules_by_name.items():
+            assert rule.get("annotations", {}).get("summary"), f"{name}: missing summary"


### PR DESCRIPTION
## Summary

PR #147 merged before its CodeRabbit review comments were addressed; this follow-up resolves them.

**Alert rule fixes (functional):**
- **WorkerSaturation**: removed the `{{ $labels.task_queue }}` reference — the Temporal SDK's `temporal_worker_task_slots_available` metric only exposes `worker_type`, so the label would have rendered empty in Slack notifications. Uses `instance` instead.
- **SuzieQStale**: description now states the true ~20-minute firing window (15-minute staleness threshold in the expr, plus `for: 5m` pending).

**Test cleanups:**
- Added missing docstrings on test classes and methods
- Split the bundled `test_every_rule_in_file_is_well_formed` into three single-focus tests (expr / severity / summary)
- Replaced the fragile `for:` duration parser with `_parse_duration_seconds`, which handles compound durations like `1h30m` and fails with a clear assertion message

**Skipped (with reason):** the `test_<what>_<when>_<expected>` renaming suggestion — these are structural invariant checks with no meaningful "when" clause; CodeRabbit itself rated it low-value.

## Test plan

- [x] 31 alert-rule tests pass
- [x] `promtool check rules`: 13 rules, SUCCESS
- [x] `uv run invoke lint` clean

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert descriptions for better clarity and accuracy.
  * Updated stale-alert wording to reflect the full expected delay more precisely.
  * Clarified worker-related alert text so it points to the relevant instance.

* **Tests**
  * Strengthened alert rule validation to catch missing summaries, expressions, and invalid severities.
  * Expanded coverage for critical alert timing and required alert fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
