### PR TITLE
feat: add Intent Coverage Trend panel to Compliance Tracking dashboard

### DIFF
--- a/changelog/71.added.md
+++ b/changelog/71.added.md
@@ -1,0 +1,1 @@
+Intent Coverage Trend panel on the Compliance Tracking dashboard: charts fleet-wide lineage coverage over time from InfluxDB (14-day window, daily mean, 95% alert threshold line), backed by a new provisioned Grafana InfluxDB datasource.

--- a/development/grafana/dashboards/compliance-tracking.json
+++ b/development/grafana/dashboards/compliance-tracking.json
@@ -41,6 +41,35 @@
         {"expr": "rate(hygiene_check_passed_total[1h])", "legendFormat": "Passed", "refId": "A"},
         {"expr": "rate(hygiene_check_failed_total[1h])", "legendFormat": "Failed", "refId": "B"}
       ]
+    },
+    {
+      "title": "Intent Coverage Trend",
+      "description": "Fleet-wide lineage coverage over time, from the hourly compliance posture writer (Issue #70). The 95% line matches the LineageCoverageDrop alert threshold.",
+      "type": "timeseries",
+      "datasource": {"type": "influxdb", "uid": "influxdb-compliance"},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "timeFrom": "14d",
+      "targets": [
+        {
+          "query": "from(bucket: \"compliance\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"compliance_posture_fleet\" and r._field == \"lineage_coverage_ratio\")\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\n  |> yield(name: \"daily mean\")",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {"thresholdsStyle": {"mode": "line"}},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 0.95}
+            ]
+          }
+        }
+      }
     }
   ],
   "schemaVersion": 39,

--- a/development/grafana/provisioning/datasources/influxdb.yml
+++ b/development/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,20 @@
+# InfluxDB datasource — compliance posture time series (Issue #71)
+# Reads the compliance bucket written hourly by `invoke backend.write-posture`.
+
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB Compliance
+    type: influxdb
+    uid: influxdb-compliance
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: false
+    editable: false
+    jsonData:
+      version: Flux
+      organization: synapse
+      defaultBucket: compliance
+      tlsSkipVerify: true
+    secureJsonData:
+      token: $INFLUXDB_TOKEN

--- a/tests/unit/test_compliance_dashboard.py
+++ b/tests/unit/test_compliance_dashboard.py
@@ -1,0 +1,95 @@
+"""Unit tests for the Compliance Tracking dashboard trend panel (Issue #71).
+
+Validates the Grafana InfluxDB datasource provisioning and the
+"Intent Coverage Trend" panel, which charts lineage coverage over time
+from the compliance_posture_fleet measurement written by the posture
+writer (Issue #70).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+GRAFANA_DIR = Path(__file__).parents[2] / "development" / "grafana"
+DATASOURCE_PATH = GRAFANA_DIR / "provisioning" / "datasources" / "influxdb.yml"
+DASHBOARD_PATH = GRAFANA_DIR / "dashboards" / "compliance-tracking.json"
+
+INFLUXDB_DATASOURCE_UID = "influxdb-compliance"
+
+
+@pytest.fixture(scope="module")
+def influx_datasource() -> dict:
+    """The provisioned InfluxDB datasource definition."""
+    assert DATASOURCE_PATH.exists(), f"{DATASOURCE_PATH} does not exist"
+    config = yaml.safe_load(DATASOURCE_PATH.read_text())
+    (datasource,) = config["datasources"]
+    return datasource
+
+
+@pytest.fixture(scope="module")
+def trend_panel() -> dict:
+    """The Intent Coverage Trend panel from the Compliance Tracking dashboard."""
+    dashboard = json.loads(DASHBOARD_PATH.read_text())
+    matches = [p for p in dashboard["panels"] if p.get("title") == "Intent Coverage Trend"]
+    assert len(matches) == 1, "expected exactly one 'Intent Coverage Trend' panel"
+    return matches[0]
+
+
+@pytest.mark.unit
+class TestInfluxDatasource:
+    """Grafana provisioning for the InfluxDB compliance datasource."""
+
+    def test_datasource_targets_compose_influxdb_service(self, influx_datasource: dict) -> None:
+        """The datasource points at the influxdb service from docker-compose-deps.yml."""
+        assert influx_datasource["type"] == "influxdb"
+        assert influx_datasource["url"] == "http://influxdb:8086"
+
+    def test_datasource_uid_is_stable_for_panel_references(self, influx_datasource: dict) -> None:
+        """Panels reference the datasource by uid, so it must be pinned."""
+        assert influx_datasource["uid"] == INFLUXDB_DATASOURCE_UID
+
+    def test_datasource_uses_flux_against_compliance_bucket(self, influx_datasource: dict) -> None:
+        """Queries use Flux against the org/bucket the posture writer targets."""
+        json_data = influx_datasource["jsonData"]
+        assert json_data["version"] == "Flux"
+        assert json_data["organization"] == "synapse"
+        assert json_data["defaultBucket"] == "compliance"
+
+    def test_datasource_token_comes_from_environment(self, influx_datasource: dict) -> None:
+        """The token is injected via env var, not hardcoded in the provisioning file."""
+        assert influx_datasource["secureJsonData"]["token"] == "$INFLUXDB_TOKEN"  # noqa: S105
+
+
+@pytest.mark.unit
+class TestIntentCoverageTrendPanel:
+    """The Intent Coverage Trend panel definition."""
+
+    def test_panel_is_a_timeseries_on_the_influx_datasource(self, trend_panel: dict) -> None:
+        """The trend renders as a timeseries bound to the InfluxDB datasource."""
+        assert trend_panel["type"] == "timeseries"
+        assert trend_panel["datasource"]["uid"] == INFLUXDB_DATASOURCE_UID
+
+    def test_panel_queries_fleet_lineage_coverage(self, trend_panel: dict) -> None:
+        """The Flux query reads lineage_coverage_ratio from compliance_posture_fleet."""
+        (target,) = trend_panel["targets"]
+        query = target["query"]
+        assert 'r._measurement == "compliance_posture_fleet"' in query
+        assert 'r._field == "lineage_coverage_ratio"' in query
+
+    def test_panel_aggregates_daily_for_week_over_week_trend(self, trend_panel: dict) -> None:
+        """Daily mean aggregation makes the week-over-week trend readable."""
+        (target,) = trend_panel["targets"]
+        assert "aggregateWindow(every: 1d, fn: mean" in target["query"]
+
+    def test_panel_displays_ratio_as_percent(self, trend_panel: dict) -> None:
+        """Coverage is a 0..1 ratio, displayed as a percentage."""
+        assert trend_panel["fieldConfig"]["defaults"]["unit"] == "percentunit"
+
+    def test_panel_marks_the_95_percent_alert_threshold(self, trend_panel: dict) -> None:
+        """The panel shows the 0.95 threshold that LineageCoverageDrop alerts on."""
+        steps = trend_panel["fieldConfig"]["defaults"]["thresholds"]["steps"]
+        assert any(step.get("value") == 0.95 for step in steps)


### PR DESCRIPTION
## Summary

Completes the Epic E monitoring batch: adds the week-over-week intent coverage trend panel to the existing Compliance Tracking dashboard (Issue #71), reading the InfluxDB data written hourly by the posture writer from #70.

## Pieces

- **New Grafana datasource** (`provisioning/datasources/influxdb.yml`): uid `influxdb-compliance`, Flux queries against org `synapse` / bucket `compliance` on the compose `influxdb` service; token injected via `$INFLUXDB_TOKEN`, not hardcoded.
- **"Intent Coverage Trend" panel**: full-width timeseries under the existing hygiene panels. Flux query takes the daily mean of `compliance_posture_fleet` / `lineage_coverage_ratio`, displayed as a percentage (0–100%), with the 0.95 threshold drawn as a line — the same threshold the `LineageCoverageDrop` alert (#80) fires on.
- **Per-panel `timeFrom: 14d` override** so the trend shows two weeks of history while the dashboard keeps its 24h default for the hygiene panels.

## Test plan

- [x] TDD: `tests/unit/test_compliance_dashboard.py` written first (red), then datasource + panel added (green) — 9 tests pinning the datasource contract and panel query/format
- [x] Full unit suite: 328 passed, coverage gate met
- [x] Dashboard JSON parses; yamllint clean on the new datasource file

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)