### PR TITLE
feat: add Intent Lifecycle Grafana dashboard

### DIFF
--- a/changelog/66.added.md
+++ b/changelog/66.added.md
@@ -1,0 +1,1 @@
+Intent Lifecycle Grafana dashboard: lineage coverage headline (InfluxDB), intent outcome rates, provisioning duration quantiles, binding failures, decommission age (Prometheus #62 metrics), and a per-device completeness drill-down standing in for forward/reverse lineage until the intent schemas land.

--- a/development/grafana/dashboards/intent-lifecycle.json
+++ b/development/grafana/dashboards/intent-lifecycle.json
@@ -1,0 +1,147 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "description": "Business intent lifecycle for platform + security audiences (Issue #66). Prometheus panels chart the #62 worker metrics; InfluxDB panels read the #70 posture data. The lineage drill-down shows per-device modeling completeness until the intent schemas enable true forward/reverse lineage.",
+  "panels": [
+    {
+      "title": "Lineage Coverage",
+      "description": "Fleet-wide lineage coverage headline (InfluxDB, written hourly by the posture writer). 95% is the LineageCoverageDrop alert threshold.",
+      "type": "stat",
+      "datasource": {"type": "influxdb", "uid": "influxdb-compliance"},
+      "gridPos": {"h": 8, "w": 6, "x": 0, "y": 0},
+      "targets": [
+        {
+          "query": "from(bucket: \"compliance\")\n  |> range(start: -2h)\n  |> filter(fn: (r) => r._measurement == \"compliance_posture_fleet\" and r._field == \"lineage_coverage_ratio\")\n  |> last()",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 0.95}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Binding Failures",
+      "description": "Intents that failed to bind to device data from Infrahub (24h).",
+      "type": "stat",
+      "gridPos": {"h": 8, "w": 6, "x": 6, "y": 0},
+      "targets": [
+        {
+          "expr": "sum(increase(intent_binding_failures_total[24h])) or vector(0)",
+          "legendFormat": "failures (24h)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 5}
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Intent Outcomes",
+      "description": "Connectivity intent deployments by outcome status.",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "targets": [
+        {
+          "expr": "sum by (status) (increase(intent_connectivity_total[1h]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "short"}}
+    },
+    {
+      "title": "Provisioning Duration",
+      "description": "gNMI SET provisioning latency quantiles from the worker histogram.",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(intent_provisioning_duration_seconds_bucket[1h])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(intent_provisioning_duration_seconds_bucket[1h])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(intent_provisioning_duration_seconds_bucket[1h])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    },
+    {
+      "title": "Decommission Age",
+      "description": "Age of intents at decommission time. Contract-only metric today — populates when the decommission flow lands.",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(intent_decommission_age_days_bucket[1d])))",
+          "legendFormat": "p50 age (days)",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(intent_decommission_age_days_bucket[1d])))",
+          "legendFormat": "p95 age (days)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "d"}}
+    },
+    {
+      "title": "Per-Device Completeness (lineage drill-down)",
+      "description": "Which devices drag lineage coverage down (latest posture per device). Replaced by true forward/reverse intent lineage once the intent schemas land in Infrahub.",
+      "type": "table",
+      "datasource": {"type": "influxdb", "uid": "influxdb-compliance"},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "targets": [
+        {
+          "query": "from(bucket: \"compliance\")\n  |> range(start: -2h)\n  |> filter(fn: (r) => r._measurement == \"compliance_posture\" and r._field == \"completeness\")\n  |> group(columns: [\"device\"])\n  |> last()\n  |> keep(columns: [\"device\", \"device_group\", \"_value\"])\n  |> group()\n  |> sort(columns: [\"_value\"])",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 1}
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["intent", "lifecycle", "compliance"],
+  "time": {"from": "now-24h", "to": "now"},
+  "title": "Intent Lifecycle",
+  "uid": "intent-lifecycle"
+}

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -134,12 +134,13 @@ Provisioned from `development/grafana/dashboards/` (see
 | 3 | Compliance Tracking | Hygiene pass rate, drift score, Intent Coverage Trend (InfluxDB) | live |
 | 4 | System Health | CPU / memory / disk / network of the platform | live |
 | 5 | Capacity Planning | 7-day utilisation trends, device count, workflow volume | live |
-| 6 | Intent Lifecycle | Business intent funnel from #62 metrics | planned (#66) |
+| 6 | Intent Lifecycle | Lineage coverage headline, intent outcomes, provisioning latency, binding failures, per-device drill-down | live |
 | 7 | Operational Intent | Override activity from #63 metrics | planned (#68) |
 
-The Compliance Tracking dashboard is the only one with two datasources:
-Prometheus for the hygiene panels and the `influxdb-compliance` datasource
-(Flux) for the Intent Coverage Trend panel.
+Compliance Tracking and Intent Lifecycle mix two datasources: Prometheus for
+worker/hygiene metrics and the `influxdb-compliance` datasource (Flux) for
+posture data. The Intent Lifecycle drill-down shows per-device modeling
+completeness until the intent schemas enable true forward/reverse lineage.
 
 ## Alert Rules Reference
 

--- a/tests/unit/test_intent_lifecycle_dashboard.py
+++ b/tests/unit/test_intent_lifecycle_dashboard.py
@@ -1,0 +1,115 @@
+"""Unit tests for the Intent Lifecycle Grafana dashboard (Issue #66).
+
+Validates the dashboard definition against the issue spec: headline lineage
+coverage, provisioning duration, binding failures, decommission age, and the
+per-device lineage drill-down, sourced from both Prometheus (#62 worker
+metrics) and InfluxDB (#70 posture data).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+DASHBOARD_PATH = Path(__file__).parents[2] / "development" / "grafana" / "dashboards" / "intent-lifecycle.json"
+
+INFLUXDB_DATASOURCE_UID = "influxdb-compliance"
+
+
+@pytest.fixture(scope="module")
+def dashboard() -> dict:
+    """Parsed dashboard JSON."""
+    assert DASHBOARD_PATH.exists(), f"{DASHBOARD_PATH} does not exist"
+    return json.loads(DASHBOARD_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def panels_by_title(dashboard: dict) -> dict[str, dict]:
+    """Dashboard panels keyed by title."""
+    return {p["title"]: p for p in dashboard["panels"]}
+
+
+def _queries(panel: dict) -> str:
+    """All target expressions/queries of a panel, concatenated."""
+    return " ".join(t.get("expr", "") + t.get("query", "") for t in panel.get("targets", []))
+
+
+@pytest.mark.unit
+class TestDashboardShape:
+    """Top-level dashboard identity and panel inventory."""
+
+    def test_dashboard_has_stable_uid_and_title(self, dashboard: dict) -> None:
+        """The dashboard is addressable at a fixed uid."""
+        assert dashboard["uid"] == "intent-lifecycle"
+        assert dashboard["title"] == "Intent Lifecycle"
+
+    def test_all_five_spec_panels_present(self, panels_by_title: dict) -> None:
+        """Every key panel from the Issue #66 spec exists."""
+        expected = {
+            "Lineage Coverage",
+            "Intent Outcomes",
+            "Provisioning Duration",
+            "Binding Failures",
+            "Decommission Age",
+            "Per-Device Completeness (lineage drill-down)",
+        }
+        missing = expected - set(panels_by_title)
+        assert not missing, f"missing panels: {sorted(missing)}"
+
+
+@pytest.mark.unit
+class TestHeadlinePanel:
+    """The lineage coverage headline number."""
+
+    def test_headline_is_a_stat_from_influxdb(self, panels_by_title: dict) -> None:
+        """Coverage headline reads the fleet ratio from InfluxDB (live data)."""
+        panel = panels_by_title["Lineage Coverage"]
+        assert panel["type"] == "stat"
+        assert panel["datasource"]["uid"] == INFLUXDB_DATASOURCE_UID
+        assert 'r._field == "lineage_coverage_ratio"' in _queries(panel)
+
+    def test_headline_shows_percent_with_alert_threshold(self, panels_by_title: dict) -> None:
+        """Displayed as a percentage with the 0.95 LineageCoverageDrop threshold."""
+        defaults = panels_by_title["Lineage Coverage"]["fieldConfig"]["defaults"]
+        assert defaults["unit"] == "percentunit"
+        assert any(s.get("value") == 0.95 for s in defaults["thresholds"]["steps"])
+
+
+@pytest.mark.unit
+class TestPrometheusPanels:
+    """Panels charting the #62 worker metrics from Prometheus."""
+
+    def test_intent_outcomes_charts_connectivity_by_status(self, panels_by_title: dict) -> None:
+        """Outcome rates come from intent_connectivity_total grouped by status."""
+        queries = _queries(panels_by_title["Intent Outcomes"])
+        assert "intent_connectivity_total" in queries
+        assert "status" in queries
+
+    def test_provisioning_duration_uses_histogram_quantiles(self, panels_by_title: dict) -> None:
+        """Duration panel shows quantiles over the provisioning histogram."""
+        queries = _queries(panels_by_title["Provisioning Duration"])
+        assert "histogram_quantile" in queries
+        assert "intent_provisioning_duration_seconds_bucket" in queries
+
+    def test_binding_failures_counts_recent_window(self, panels_by_title: dict) -> None:
+        """Binding failures panel reads the #62 counter."""
+        assert "intent_binding_failures_total" in _queries(panels_by_title["Binding Failures"])
+
+    def test_decommission_age_reads_contract_histogram(self, panels_by_title: dict) -> None:
+        """Decommission panel queries the (contract-only) age histogram."""
+        assert "intent_decommission_age_days_bucket" in _queries(panels_by_title["Decommission Age"])
+
+
+@pytest.mark.unit
+class TestDrilldownPanel:
+    """Per-device lineage drill-down (stand-in until intent schemas land)."""
+
+    def test_drilldown_lists_per_device_completeness_from_influxdb(self, panels_by_title: dict) -> None:
+        """Drill-down groups posture completeness by device from InfluxDB."""
+        panel = panels_by_title["Per-Device Completeness (lineage drill-down)"]
+        assert panel["datasource"]["uid"] == INFLUXDB_DATASOURCE_UID
+        query = _queries(panel)
+        assert 'r._measurement == "compliance_posture"' in query
+        assert 'r._field == "completeness"' in query


### PR DESCRIPTION
## Summary

Adds the Intent Lifecycle dashboard (Issue #66) — dashboard 6 of the 7-dashboard plan in `docs/measurement.md`. Mixed datasources per the issue spec: Prometheus for the live #62 worker metrics, InfluxDB for posture data.

## Panels

| Panel | Source | Notes |
|---|---|---|
| Lineage Coverage (headline stat) | InfluxDB | live fleet ratio, shown as %, 0.95 alert threshold marked |
| Binding Failures (24h stat) | Prometheus | `intent_binding_failures_total` |
| Intent Outcomes | Prometheus | `intent_connectivity_total` by status |
| Provisioning Duration | Prometheus | p50/p95/p99 over the worker histogram |
| Decommission Age | Prometheus | contract-only metric — panel populates when the decommission flow lands |
| Per-Device Completeness (drill-down) | InfluxDB | worst-first table; stands in for forward/reverse lineage until the intent schemas exist |

The forward/reverse lineage drill-down from the issue can't be built yet (no intent objects in Infrahub), so the drill-down shows which devices drag coverage down — same question, available data — and both the panel description and `docs/measurement.md` say what replaces it.

## Test plan

- [x] TDD: `tests/unit/test_intent_lifecycle_dashboard.py` written first (red) — 9 tests pinning uid, panel inventory, datasource bindings, and each panel's queries
- [x] Full unit suite: 347 passed; lint clean; dashboard JSON parses

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)