### PR TITLE
fix: apply drift response policy instead of unconditional remediation

### DIFF
--- a/changelog/154.changed.md
+++ b/changelog/154.changed.md
@@ -1,0 +1,1 @@
+`DriftRemediationWorkflow` now applies a drift response policy instead of unconditionally auto-remediating: devices in `maintenance` are never touched (out-of-band incident fixes are no longer silently reverted), cosmetic drift is audited without redeployment, and only critical drift on an active device triggers remediation.

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -103,9 +103,15 @@
    - Was there a recent manual change on the device?
    - Was there an out-of-band configuration update?
 
-3. **Remediate:**
+3. **Know what the automation already did.** `DriftRemediationWorkflow` applies a drift response policy:
+   - Device status `maintenance` → remediation **suppressed** (audit event `DRIFT_SUPPRESSED_MAINTENANCE`); out-of-band fixes are never silently reverted
+   - **Cosmetic** drift (e.g. description changes) → audited only (`DRIFT_LOGGED`), not remediated
+   - **Critical** drift on an active device → backed up, re-deployed from intent, validated (`REMEDIATED`)
+
+4. **Remediate what the policy left for you:**
    - If **unintentional**: Re-run the `NetworkChangeWorkflow` to push the correct intent from Infrahub
    - If **intentional**: Update Infrahub to match the new desired state, then re-run the workflow
+   - If suppressed during maintenance: after the window closes, set the device status back to `active` and re-run the drift check
 
 ---
 

--- a/tests/unit/test_drift_remediation_workflow.py
+++ b/tests/unit/test_drift_remediation_workflow.py
@@ -18,9 +18,11 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from synapse_workers.workflows.drift_remediation_workflow import (
+    DriftAction,
     DriftRemediationWorkflow,
     DriftSeverity,
     classify_drift,
+    decide_drift_action,
 )
 from tests.conftest import (
     _recorded_audit_events,
@@ -38,6 +40,7 @@ IP = "172.20.20.3"
 INTENDED_CONFIG = '{"interface": [{"name": "ethernet-1/1"}]}'
 RUNNING_CONFIG_CLEAN = '{"interface": [{"name": "ethernet-1/1"}]}'
 RUNNING_CONFIG_DRIFTED = '{"interface": [{"name": "ethernet-1/1", "admin-state": "disable"}]}'
+RUNNING_CONFIG_COSMETIC = '{"interface": [{"name": "ethernet-1/1", "description": "temp note"}]}'
 
 
 @activity.defn(name="fetch_device_config")
@@ -45,9 +48,26 @@ async def mock_fetch_device_config(device_hostname: str) -> dict:
     return {
         "hostname": device_hostname,
         "ip_address": IP,
+        "status": "active",
         "bgp": {"router_id": "10.1.0.1", "local_asn": 65000, "sessions": []},
         "interfaces": {"hostname": device_hostname, "interfaces": [{"name": "ethernet-1/1"}]},
     }
+
+
+@activity.defn(name="fetch_device_config")
+async def mock_fetch_device_config_maintenance(device_hostname: str) -> dict:
+    return {
+        "hostname": device_hostname,
+        "ip_address": IP,
+        "status": "maintenance",
+        "bgp": {"router_id": "10.1.0.1", "local_asn": 65000, "sessions": []},
+        "interfaces": {"hostname": device_hostname, "interfaces": [{"name": "ethernet-1/1"}]},
+    }
+
+
+@activity.defn(name="fetch_running_config")
+async def mock_fetch_running_config_cosmetic(device_hostname: str, ip_address: str) -> str:
+    return RUNNING_CONFIG_COSMETIC
 
 
 @activity.defn(name="render_intended_config")
@@ -128,6 +148,11 @@ class TestClassifyDrift:
         assert result.has_drift is False
         assert result.severity == DriftSeverity.NONE
 
+    def test_drift_severity_when_only_description_changed_returns_cosmetic(self) -> None:
+        result = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_COSMETIC)
+        assert result.has_drift is True
+        assert result.severity == DriftSeverity.COSMETIC
+
     def test_drift_severity_when_admin_state_changed_returns_critical(self) -> None:
         result = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_DRIFTED)
         assert result.has_drift is True
@@ -137,6 +162,31 @@ class TestClassifyDrift:
         result = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_DRIFTED)
         assert result.has_drift is True
         assert result.diff != ""
+
+
+class TestDecideDriftAction:
+    """Drift response policy (Issue #154): severity + device status -> action."""
+
+    def test_no_drift_takes_no_action(self) -> None:
+        drift = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_CLEAN)
+        assert decide_drift_action(drift, "active") == DriftAction.NONE
+
+    def test_critical_drift_on_active_device_remediates(self) -> None:
+        drift = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_DRIFTED)
+        assert decide_drift_action(drift, "active") == DriftAction.REMEDIATE
+
+    def test_cosmetic_drift_is_logged_not_remediated(self) -> None:
+        drift = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_COSMETIC)
+        assert decide_drift_action(drift, "active") == DriftAction.LOG_ONLY
+
+    def test_maintenance_suppresses_remediation_even_for_critical_drift(self) -> None:
+        """An out-of-band fix during maintenance must not be silently reverted."""
+        drift = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_DRIFTED)
+        assert decide_drift_action(drift, "maintenance") == DriftAction.SUPPRESS_MAINTENANCE
+
+    def test_maintenance_suppresses_cosmetic_drift_too(self) -> None:
+        drift = classify_drift(INTENDED_CONFIG, RUNNING_CONFIG_COSMETIC)
+        assert decide_drift_action(drift, "maintenance") == DriftAction.SUPPRESS_MAINTENANCE
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +245,32 @@ DRIFT_ACTIVITIES_VALIDATION_FAIL = [
     mock_log_audit_event,
 ]
 
+DRIFT_ACTIVITIES_COSMETIC = [
+    mock_fetch_device_config,
+    mock_render_intended_config,
+    mock_fetch_running_config_cosmetic,
+    mock_deploy_config,
+    mock_validate_bgp,
+    mock_validate_interfaces,
+    mock_update_device_status,
+    mock_backup_running_config,
+    mock_store_backup,
+    mock_log_audit_event,
+]
+
+DRIFT_ACTIVITIES_MAINTENANCE = [
+    mock_fetch_device_config_maintenance,
+    mock_render_intended_config,
+    mock_fetch_running_config_drifted,
+    mock_deploy_config,
+    mock_validate_bgp,
+    mock_validate_interfaces,
+    mock_update_device_status,
+    mock_backup_running_config,
+    mock_store_backup,
+    mock_log_audit_event,
+]
+
 
 @pytest.mark.asyncio
 async def test_run_when_configs_match_returns_no_drift() -> None:
@@ -216,6 +292,57 @@ async def test_run_when_configs_match_returns_no_drift() -> None:
             task_queue="test-drift",
         )
         assert result == "NO_DRIFT"
+
+
+@pytest.mark.asyncio
+async def test_run_when_cosmetic_drift_logs_without_remediating() -> None:
+    """Cosmetic drift is audited but never redeployed (Issue #154)."""
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue="test-drift",
+            workflows=[DriftRemediationWorkflow],
+            activities=DRIFT_ACTIVITIES_COSMETIC,
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ),
+    ):
+        result = await env.client.execute_workflow(
+            DriftRemediationWorkflow.run,
+            args=[DEVICE, IP],
+            id=f"drift-test-cosmetic-{DEVICE}",
+            task_queue="test-drift",
+        )
+        assert result == "DRIFT_LOGGED"
+        assert _recorded_store_backup_calls == []
+        event_types = [e[0] for e in _recorded_audit_events]
+        assert "DRIFT_DETECTED" in event_types
+        assert "DRIFT_LOGGED" in event_types
+
+
+@pytest.mark.asyncio
+async def test_run_when_device_in_maintenance_suppresses_remediation() -> None:
+    """Critical drift on a device in maintenance is suppressed, not reverted (Issue #154)."""
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue="test-drift",
+            workflows=[DriftRemediationWorkflow],
+            activities=DRIFT_ACTIVITIES_MAINTENANCE,
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ),
+    ):
+        result = await env.client.execute_workflow(
+            DriftRemediationWorkflow.run,
+            args=[DEVICE, IP],
+            id=f"drift-test-maintenance-{DEVICE}",
+            task_queue="test-drift",
+        )
+        assert result == "DRIFT_SUPPRESSED_MAINTENANCE"
+        assert _recorded_store_backup_calls == []
+        event_types = [e[0] for e in _recorded_audit_events]
+        assert "DRIFT_SUPPRESSED_MAINTENANCE" in event_types
 
 
 @pytest.mark.asyncio

--- a/workers/synapse_workers/activities/infrahub_activities.py
+++ b/workers/synapse_workers/activities/infrahub_activities.py
@@ -26,6 +26,7 @@ async def fetch_device_config(device_hostname: str) -> dict:
     Returns:
         dict with keys:
             - hostname: device hostname
+            - status: device lifecycle status (drives the drift response policy)
             - bgp: BGPTemplateVars as dict
             - interfaces: InterfacesTemplateVars as dict
     """
@@ -37,6 +38,7 @@ async def fetch_device_config(device_hostname: str) -> dict:
         config = client.get_device_config(device_hostname)
         return {
             "hostname": device_hostname,
+            "status": config.device.status,
             "bgp": config.to_bgp_template_vars().model_dump(),
             "interfaces": config.to_interface_template_vars().model_dump(),
         }

--- a/workers/synapse_workers/workflows/drift_remediation_workflow.py
+++ b/workers/synapse_workers/workflows/drift_remediation_workflow.py
@@ -35,6 +35,15 @@ class DriftSeverity(enum.StrEnum):
     CRITICAL = "critical"
 
 
+class DriftAction(enum.StrEnum):
+    """Response action for detected drift (Issue #154)."""
+
+    NONE = "none"
+    LOG_ONLY = "log_only"
+    SUPPRESS_MAINTENANCE = "suppress_maintenance"
+    REMEDIATE = "remediate"
+
+
 @dataclass
 class DriftResult:
     """Result of comparing intended vs running configuration."""
@@ -84,6 +93,25 @@ def classify_drift(intended_json: str, running_json: str) -> DriftResult:
     return DriftResult(has_drift=True, severity=severity, diff="\n".join(diff_lines))
 
 
+def decide_drift_action(drift: DriftResult, device_status: str) -> DriftAction:
+    """Map drift severity and device status to a response action.
+
+    Deterministic pure function — safe to call inside workflow code.
+
+    Policy: a device in maintenance is never touched (an out-of-band fix
+    during an incident must not be silently reverted); cosmetic drift is
+    audited but not remediated; only critical drift on an active device
+    triggers remediation.
+    """
+    if not drift.has_drift:
+        return DriftAction.NONE
+    if device_status == "maintenance":
+        return DriftAction.SUPPRESS_MAINTENANCE
+    if drift.severity is DriftSeverity.COSMETIC:
+        return DriftAction.LOG_ONLY
+    return DriftAction.REMEDIATE
+
+
 # Retry policy for device communication
 device_retry_policy = RetryPolicy(
     initial_interval=timedelta(seconds=5),
@@ -101,18 +129,24 @@ class DriftRemediationWorkflow:
       1. Fetch intended config from Infrahub
       2. Generate intended SR Linux JSON from Infrahub data
       3. Fetch running config from device via gNMI GET
-      4. Diff intended vs actual — classify drift severity
+      4. Diff intended vs actual — classify severity, decide response action
       5. If no drift: return early
-      6. If drift: backup running config, re-deploy intended, validate
-      7. Report drift event via audit log
+      6. Cosmetic drift: audit only. Device in maintenance: suppress
+         (out-of-band fixes must not be silently reverted)
+      7. Critical drift on an active device: backup running config,
+         re-deploy intended, validate
+      8. Report drift events via audit log
     """
 
     @workflow.run
     async def run(self, device_hostname: str, ip_address: str) -> str:
-        """Execute drift detection and remediation.
+        """Execute drift detection and respond per the drift policy.
 
         Returns:
-            "NO_DRIFT" if configs match, "REMEDIATED" if drift was fixed.
+            "NO_DRIFT" if configs match,
+            "DRIFT_LOGGED" for cosmetic drift (audited, not remediated),
+            "DRIFT_SUPPRESSED_MAINTENANCE" if the device is in maintenance,
+            "REMEDIATED" if critical drift was fixed.
 
         Raises:
             ApplicationError: If remediation deployment or validation fails.
@@ -142,21 +176,44 @@ class DriftRemediationWorkflow:
             retry_policy=device_retry_policy,
         )
 
-        # 4. Classify drift (deterministic — runs in workflow)
+        # 4. Classify drift and decide the response (deterministic — runs in workflow)
         drift = classify_drift(intended_config_json, running_config_json)
+        action = decide_drift_action(drift, device_data.get("status", "active"))
 
-        if not drift.has_drift:
+        if action is DriftAction.NONE:
             workflow.logger.info(f"No drift detected on {device_hostname}")
             return "NO_DRIFT"
 
-        # 5. Drift detected — log and remediate
+        # 5. Drift detected — audit, then act per policy
         workflow.logger.warning(f"Drift detected on {device_hostname}: severity={drift.severity.value}\n{drift.diff}")
 
         await workflow.execute_activity(
             log_audit_event,
-            args=["DRIFT_DETECTED", device_hostname, f"severity={drift.severity.value} diff={drift.diff}"],
+            args=[
+                "DRIFT_DETECTED",
+                device_hostname,
+                f"severity={drift.severity.value} action={action.value} diff={drift.diff}",
+            ],
             start_to_close_timeout=timedelta(seconds=10),
         )
+
+        if action is DriftAction.SUPPRESS_MAINTENANCE:
+            workflow.logger.warning(f"{device_hostname} is in maintenance — drift remediation suppressed")
+            await workflow.execute_activity(
+                log_audit_event,
+                args=["DRIFT_SUPPRESSED_MAINTENANCE", device_hostname, f"severity={drift.severity.value}"],
+                start_to_close_timeout=timedelta(seconds=10),
+            )
+            return "DRIFT_SUPPRESSED_MAINTENANCE"
+
+        if action is DriftAction.LOG_ONLY:
+            workflow.logger.info(f"Cosmetic drift on {device_hostname} — logged, not remediated")
+            await workflow.execute_activity(
+                log_audit_event,
+                args=["DRIFT_LOGGED", device_hostname, f"severity={drift.severity.value}"],
+                start_to_close_timeout=timedelta(seconds=10),
+            )
+            return "DRIFT_LOGGED"
 
         # 6. Backup current (drifted) config before remediation
         backup_json = await workflow.execute_activity(


### PR DESCRIPTION
## Summary

Implements the drift response policy from Issue #154 (surfaced by [Sif Baksh's intent-vs-operational-state article](https://sifbaksh.com/blog/source-of-truth-intent-vs-operational-state-network-automation/) — "most importantly: define drift response actions").

**Before:** `DriftRemediationWorkflow` classified drift as COSMETIC or CRITICAL, then ignored the classification — every drift got backup → redeploy → validate. The dangerous case: an emergency out-of-band fix during an incident would be silently reverted.

**After:** a pure, deterministic `decide_drift_action(drift, device_status)` maps severity + device status to an action:

| Condition | Action | Return / audit |
|---|---|---|
| no drift | none | `NO_DRIFT` |
| device status `maintenance` (any severity) | suppress | `DRIFT_SUPPRESSED_MAINTENANCE` |
| cosmetic drift, active device | audit only | `DRIFT_LOGGED` |
| critical drift, active device | remediate (unchanged) | `REMEDIATED` |

## Details

- `fetch_device_config` now returns the device lifecycle `status` (drives the policy; defaults to `active` if absent for backward compatibility)
- The `DRIFT_DETECTED` audit event records the chosen action alongside severity
- Runbook §3 documents the policy and adds the post-maintenance re-check step
- The decision function is pure and runs in workflow code (deterministic, replay-safe); all I/O stays in activities

## Test plan

- [x] TDD: policy tests written first — 5 `decide_drift_action` cases (including maintenance suppressing *critical* drift) + 2 new Temporal `WorkflowEnvironment` tests asserting cosmetic drift returns `DRIFT_LOGGED` with zero backup/deploy calls, and maintenance returns `DRIFT_SUPPRESSED_MAINTENANCE`
- [x] Existing remediation-path tests unchanged and passing (critical + active still remediates)
- [x] Full unit suite: 355 passed; lint clean

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)