### PR TITLE
feat: add Alertmanager maintenance-window suppression and inhibit rules

### DIFF
--- a/changelog/157.added.md
+++ b/changelog/157.added.md
@@ -1,0 +1,1 @@
+Alertmanager maintenance-window suppression: warning/info alerts are muted during the `maintenance-window` time interval (critical always pages), and a firing critical alert inhibits warning/info alerts for the same instance.

--- a/development/prometheus/alertmanager.yml
+++ b/development/prometheus/alertmanager.yml
@@ -4,6 +4,26 @@ global:
   resolve_timeout: 5m
   slack_api_url: "${SLACK_WEBHOOK_URL}"
 
+# Planned maintenance window (Issue #157) — warnings and info alerts are
+# muted while planned work runs; critical alerts always page.
+# Adjust the window to match the actual change calendar.
+time_intervals:
+  - name: maintenance-window
+    time_intervals:
+      - weekdays: ["sunday"]
+        times:
+          - start_time: "02:00"
+            end_time: "06:00"
+
+# A firing critical alert suppresses warning/info noise for the same
+# instance — one page per incident, not a cascade.
+inhibit_rules:
+  - source_matchers:
+      - 'severity="critical"'
+    target_matchers:
+      - 'severity=~"warning|info"'
+    equal: ["instance"]
+
 route:
   receiver: "slack-default"
   group_by: ["alertname", "device"]
@@ -12,20 +32,27 @@ route:
   repeat_interval: 4h
 
   routes:
-    # Critical alerts — immediate notification
+    # Critical alerts — immediate notification, never muted
     - match:
         severity: critical
       receiver: "slack-critical"
       group_wait: 10s
       repeat_interval: 1h
 
-    # Warning alerts — batched every 15 minutes
+    # Warning alerts — batched every 15 minutes, muted during maintenance
     - match:
         severity: warning
       receiver: "slack-warning"
       group_wait: 1m
       group_interval: 15m
       repeat_interval: 4h
+      mute_time_intervals: ["maintenance-window"]
+
+    # Info alerts — default channel, muted during maintenance
+    - match:
+        severity: info
+      receiver: "slack-default"
+      mute_time_intervals: ["maintenance-window"]
 
 receivers:
   - name: "slack-default"

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -147,9 +147,12 @@ completeness until the intent schemas enable true forward/reverse lineage.
 Defined in `development/prometheus/alert_rules.yml` (13 rules), validated in
 CI by `tests/unit/test_alert_rules.py`, routed by
 `development/prometheus/alertmanager.yml`:
-critical → `#network-synapse-critical` (immediate, repeat 1h);
+critical → `#network-synapse-critical` (immediate, repeat 1h, never muted);
 warning → `#network-synapse-alerts` (batched 15m);
 info → default channel.
+Warning and info alerts are muted during the `maintenance-window` time
+interval (Sunday 02:00–06:00 UTC by default), and a firing critical alert
+inhibits warning/info alerts for the same instance.
 
 | Alert | Severity | Fires when | Metric domain |
 |-------|----------|------------|---------------|

--- a/tests/unit/test_alertmanager_config.py
+++ b/tests/unit/test_alertmanager_config.py
@@ -1,0 +1,84 @@
+"""Unit tests for the Alertmanager configuration (Issue #157).
+
+Validates maintenance-window suppression and inhibit rules: warnings and
+info alerts are muted during the maintenance window, critical alerts always
+page, and a firing critical alert inhibits downstream warnings for the same
+instance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+CONFIG_PATH = Path(__file__).parents[2] / "development" / "prometheus" / "alertmanager.yml"
+
+
+@pytest.fixture(scope="module")
+def config() -> dict:
+    """Parsed alertmanager.yml."""
+    return yaml.safe_load(CONFIG_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def routes_by_severity(config: dict) -> dict[str, dict]:
+    """Child routes keyed by the severity they match."""
+    return {r["match"]["severity"]: r for r in config["route"]["routes"] if "severity" in r.get("match", {})}
+
+
+@pytest.mark.unit
+class TestMaintenanceWindow:
+    """Mute time interval definition and wiring."""
+
+    def test_maintenance_window_interval_is_defined(self, config: dict) -> None:
+        """A named maintenance-window time interval exists."""
+        names = [ti["name"] for ti in config.get("time_intervals", [])]
+        assert "maintenance-window" in names
+
+    def test_warning_route_is_muted_during_maintenance(self, routes_by_severity: dict) -> None:
+        """Warning alerts are suppressed during the maintenance window."""
+        assert routes_by_severity["warning"].get("mute_time_intervals") == ["maintenance-window"]
+
+    def test_info_route_is_muted_during_maintenance(self, routes_by_severity: dict) -> None:
+        """Info alerts are suppressed during the maintenance window."""
+        assert routes_by_severity["info"].get("mute_time_intervals") == ["maintenance-window"]
+
+    def test_critical_route_is_never_muted(self, routes_by_severity: dict) -> None:
+        """Critical alerts must page even during maintenance."""
+        assert "mute_time_intervals" not in routes_by_severity["critical"]
+
+    def test_every_mute_reference_points_to_a_defined_interval(self, config: dict) -> None:
+        """No route references an undefined time interval."""
+        defined = {ti["name"] for ti in config.get("time_intervals", [])}
+        for route in config["route"].get("routes", []):
+            for ref in route.get("mute_time_intervals", []):
+                assert ref in defined, f"route references undefined interval {ref!r}"
+
+
+@pytest.mark.unit
+class TestInhibitRules:
+    """Critical alerts inhibit downstream noise for the same instance."""
+
+    def test_critical_inhibits_warning_and_info_for_same_instance(self, config: dict) -> None:
+        """A firing critical alert suppresses warning/info alerts sharing the instance."""
+        rules = config.get("inhibit_rules", [])
+        assert any(
+            'severity="critical"' in " ".join(rule.get("source_matchers", []))
+            and any("warning" in m and "info" in m for m in rule.get("target_matchers", []))
+            and "instance" in rule.get("equal", [])
+            for rule in rules
+        ), "missing critical-inhibits-warning/info rule keyed on instance"
+
+
+@pytest.mark.unit
+class TestRouteConsistency:
+    """Structural sanity of the routing tree."""
+
+    def test_all_route_receivers_are_defined(self, config: dict) -> None:
+        """The root and every child route point at a defined receiver."""
+        defined = {r["name"] for r in config["receivers"]}
+        assert config["route"]["receiver"] in defined
+        for route in config["route"].get("routes", []):
+            assert route["receiver"] in defined, f"undefined receiver {route['receiver']!r}"


### PR DESCRIPTION
## Summary

Implements Issue #157: planned maintenance no longer pages, and a critical alert doesn't cascade into warning noise.

- **`maintenance-window` time interval** (Sunday 02:00–06:00 UTC default — adjust to the real change calendar): warning and info routes are muted during it; the **critical route is deliberately never muted**.
- **New explicit info sub-route** — info alerts previously fell through to the root route, which couldn't be muted without also affecting unmatched alerts.
- **Inhibit rule**: `severity="critical"` suppresses `severity=~"warning|info"` for the same `instance` — one page per incident.

## Test plan

- [x] TDD: `tests/unit/test_alertmanager_config.py` written first (4 red / 3 green) — interval definition, per-severity mute wiring, critical-never-muted, mute-reference integrity, inhibit rule, receiver consistency
- [x] `amtool check-config` passes (with the `${SLACK_WEBHOOK_URL}` placeholder substituted — amtool can't parse env-var placeholders, pre-existing)
- [x] yamllint + full lint clean

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)