### PR TITLE
feat: add intent metadata attributes to SoT schemas

### DIFF
--- a/backend/network_synapse/schemas/bgp_session.yml
+++ b/backend/network_synapse/schemas/bgp_session.yml
@@ -19,10 +19,29 @@
 #   - Extension to DcimGenericDevice: adds 'asn' relationship
 #   - Extension to OrganizationGeneric: adds 'asn' relationship
 #
-# No additional custom BGP schema needed — the schema-library extension covers our use case.
-# This file is kept as documentation of the schema architecture.
+# The schema-library extension covers the session modeling itself; this file
+# adds the project's intent metadata attributes (Issue #155) on top.
 ---
 # yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
 version: "1.0"
-# Schema provided by library/schema-library/extensions/routing_bgp/bgp.yml
-# No custom nodes or extensions needed for BGP
+
+extensions:
+  nodes:
+    - kind: RoutingBGPSession
+      attributes:
+        # Intent metadata (Issue #155): ownership, origin, validity
+        - name: owner
+          kind: Text
+          optional: true
+          description: "Team or person accountable for this intent"
+          order_weight: 1520
+        - name: origin
+          kind: Text
+          optional: true
+          description: "Change reference or ticket that introduced this intent"
+          order_weight: 1530
+        - name: valid_until
+          kind: DateTime
+          optional: true
+          description: "Intent validity deadline; unset means permanent (overrides set this)"
+          order_weight: 1540

--- a/backend/network_synapse/schemas/load_schemas.py
+++ b/backend/network_synapse/schemas/load_schemas.py
@@ -54,6 +54,7 @@ SCHEMA_LOAD_BATCHES = [
     [
         "backend/network_synapse/schemas/network_device.yml",
         "backend/network_synapse/schemas/network_interface.yml",
+        "backend/network_synapse/schemas/bgp_session.yml",
     ],
 ]
 

--- a/backend/network_synapse/schemas/network_device.yml
+++ b/backend/network_synapse/schemas/network_device.yml
@@ -22,6 +22,22 @@ extensions:
           optional: true
           description: "Containerlab node name (e.g., clab-spine-leaf-lab-spine01)"
           order_weight: 1510
+        # Intent metadata (Issue #155): ownership, origin, validity
+        - name: owner
+          kind: Text
+          optional: true
+          description: "Team or person accountable for this intent"
+          order_weight: 1520
+        - name: origin
+          kind: Text
+          optional: true
+          description: "Change reference or ticket that introduced this intent"
+          order_weight: 1530
+        - name: valid_until
+          kind: DateTime
+          optional: true
+          description: "Intent validity deadline; unset means permanent (overrides set this)"
+          order_weight: 1540
       relationships:
         - name: asn
           peer: RoutingAutonomousSystem

--- a/backend/network_synapse/schemas/network_interface.yml
+++ b/backend/network_synapse/schemas/network_interface.yml
@@ -33,3 +33,19 @@ extensions:
               label: Access
               description: "Host-facing access port"
               color: "#D7BDE2"
+        # Intent metadata (Issue #155): ownership, origin, validity
+        - name: owner
+          kind: Text
+          optional: true
+          description: "Team or person accountable for this intent"
+          order_weight: 1520
+        - name: origin
+          kind: Text
+          optional: true
+          description: "Change reference or ticket that introduced this intent"
+          order_weight: 1530
+        - name: valid_until
+          kind: DateTime
+          optional: true
+          description: "Intent validity deadline; unset means permanent (overrides set this)"
+          order_weight: 1540

--- a/changelog/155.added.md
+++ b/changelog/155.added.md
@@ -1,0 +1,1 @@
+Intent metadata attributes on all SoT schema extensions (`DcimDevice`, `InterfacePhysical`, `RoutingBGPSession`): `owner`, `origin` (change ref), and `valid_until` (validity deadline — groundwork for operational overrides). All optional; `bgp_session.yml` now carries a real extension and joins the schema load order.

--- a/tests/unit/test_intent_metadata_schema.py
+++ b/tests/unit/test_intent_metadata_schema.py
@@ -1,0 +1,83 @@
+"""Unit tests for intent metadata schema attributes (Issue #155).
+
+Structured intent needs ownership, origin, and validity metadata (per the
+intent-vs-operational-state analysis). Every extended SoT kind must carry:
+
+- owner       (Text)     — team/person accountable for the intent
+- origin      (Text)     — change ref / ticket that introduced it
+- valid_until (DateTime) — validity period; groundwork for OperationalOverride (#63)
+
+All three are optional so existing seed data keeps loading unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCHEMA_DIR = Path(__file__).parents[2] / "backend" / "network_synapse" / "schemas"
+
+# Schema file -> extended kind that must carry the metadata attributes
+EXTENDED_KINDS = {
+    "network_device.yml": "DcimDevice",
+    "network_interface.yml": "InterfacePhysical",
+    "bgp_session.yml": "RoutingBGPSession",
+}
+
+METADATA_ATTRIBUTES = {
+    "owner": "Text",
+    "origin": "Text",
+    "valid_until": "DateTime",
+}
+
+
+def _node_attributes(schema_file: str, kind: str) -> dict[str, dict]:
+    """The attribute definitions of `kind` in `schema_file`, keyed by name."""
+    schema = yaml.safe_load((SCHEMA_DIR / schema_file).read_text())
+    for node in schema.get("extensions", {}).get("nodes", []):
+        if node.get("kind") == kind:
+            return {a["name"]: a for a in node.get("attributes", [])}
+    pytest.fail(f"{schema_file}: no extension node for kind {kind!r}")
+
+
+@pytest.mark.unit
+class TestIntentMetadataAttributes:
+    """Every extended SoT kind carries owner/origin/valid_until."""
+
+    @pytest.mark.parametrize(("schema_file", "kind"), sorted(EXTENDED_KINDS.items()))
+    def test_kind_has_all_metadata_attributes(self, schema_file: str, kind: str) -> None:
+        """owner, origin, and valid_until exist on the extended kind."""
+        attributes = _node_attributes(schema_file, kind)
+        missing = set(METADATA_ATTRIBUTES) - set(attributes)
+        assert not missing, f"{kind} missing metadata attributes: {sorted(missing)}"
+
+    @pytest.mark.parametrize(("schema_file", "kind"), sorted(EXTENDED_KINDS.items()))
+    def test_metadata_attributes_have_correct_kinds(self, schema_file: str, kind: str) -> None:
+        """valid_until is a DateTime; owner and origin are Text."""
+        attributes = _node_attributes(schema_file, kind)
+        for name, expected_kind in METADATA_ATTRIBUTES.items():
+            assert attributes[name]["kind"] == expected_kind, f"{kind}.{name}"
+
+    @pytest.mark.parametrize(("schema_file", "kind"), sorted(EXTENDED_KINDS.items()))
+    def test_metadata_attributes_are_optional(self, schema_file: str, kind: str) -> None:
+        """Metadata must be optional so existing seed data loads unchanged."""
+        attributes = _node_attributes(schema_file, kind)
+        for name in METADATA_ATTRIBUTES:
+            assert attributes[name].get("optional") is True, f"{kind}.{name} must be optional"
+
+    @pytest.mark.parametrize(("schema_file", "kind"), sorted(EXTENDED_KINDS.items()))
+    def test_metadata_attributes_have_descriptions(self, schema_file: str, kind: str) -> None:
+        """Each metadata attribute documents what it records."""
+        attributes = _node_attributes(schema_file, kind)
+        for name in METADATA_ATTRIBUTES:
+            assert attributes[name].get("description"), f"{kind}.{name} missing description"
+
+    def test_every_metadata_schema_file_is_in_the_load_order(self) -> None:
+        """The loader must ship every schema file that now carries extensions."""
+        from network_synapse.schemas.load_schemas import SCHEMA_LOAD_ORDER
+
+        loaded = {Path(entry).name for entry in SCHEMA_LOAD_ORDER}
+        missing = set(EXTENDED_KINDS) - loaded
+        assert not missing, f"schema files not in SCHEMA_LOAD_ORDER: {sorted(missing)}"


### PR DESCRIPTION
## Summary

Implements Issue #155: every project schema extension (`DcimDevice`, `InterfacePhysical`, `RoutingBGPSession`) now carries the structured-intent metadata from the [intent-vs-operational-state analysis](https://sifbaksh.com/blog/source-of-truth-intent-vs-operational-state-network-automation/):

| Attribute | Kind | Records |
|---|---|---|
| `owner` | Text | team/person accountable for the intent |
| `origin` | Text | change ref / ticket that introduced it |
| `valid_until` | DateTime | validity deadline; unset = permanent |

`valid_until` is deliberate groundwork for the #63 override work — an operational override *is* intent with a validity period.

## Notes

- All attributes optional → existing seed data loads unchanged.
- `bgp_session.yml` was documentation-only; it now carries a real `RoutingBGPSession` extension and is added to `SCHEMA_LOAD_BATCHES` batch 3 (it wasn't in the load order at all before).
- Local end-to-end load couldn't be verified — the local Infrahub instance 500s on even the base schemas (pre-existing instance health issue, noted separately). The CI **Schema Validation** job loads all schemas into a fresh Infrahub and is the authoritative check for this PR.

## Test plan

- [x] TDD: `tests/unit/test_intent_metadata_schema.py` written first (12 red) — presence, kinds, optionality, and descriptions across all three extended kinds, plus a loader-inclusion test that catches schema files missing from `SCHEMA_LOAD_ORDER`
- [x] Full unit suite: 368 passed; lint + yamllint clean
- [ ] CI Schema Validation (fresh Infrahub load) — runs on this PR

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)