### PR TITLE
feat: add operational intent schema (override, window, action)

### DIFF
--- a/backend/network_synapse/schemas/load_schemas.py
+++ b/backend/network_synapse/schemas/load_schemas.py
@@ -55,6 +55,7 @@ SCHEMA_LOAD_BATCHES = [
         "backend/network_synapse/schemas/network_device.yml",
         "backend/network_synapse/schemas/network_interface.yml",
         "backend/network_synapse/schemas/bgp_session.yml",
+        "backend/network_synapse/schemas/operational_override.yml",
     ],
 ]
 

--- a/backend/network_synapse/schemas/operational_override.yml
+++ b/backend/network_synapse/schemas/operational_override.yml
@@ -1,0 +1,172 @@
+# Infrahub schema: Operational Intent — time-bounded overrides (Issue #161)
+#
+# Implements the 3-object operational intent model (see the intent-model
+# skill): a deviation from as-built intent that is always time-bounded,
+# accountable, and auditable.
+#
+#   OperationalOverride — the sanctioned deviation (what + why + who)
+#   OverrideWindow      — the time bounds (end_time required, auto-revert)
+#   OverrideAction      — the config change applied (before/after JSON)
+#
+# original_state is captured for audit and manual fallback; the
+# OperationalOverrideWorkflow's auto-revert converges the device to the
+# *current* SoT intent, not this snapshot (agreed in #161).
+#
+# Dependencies: base dcim schema (DcimDevice) must be loaded first.
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+nodes:
+  - name: Override
+    namespace: Operational
+    description: "Time-bounded, sanctioned deviation from as-built intent"
+    label: Operational Override
+    icon: mdi:clock-alert-outline
+    default_filter: name__value
+    display_labels:
+      - name__value
+    order_by:
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+        description: "Short identifier for this override (e.g. leaf01-drain-2026-07-06)"
+        order_weight: 1000
+      - name: override_type
+        kind: Dropdown
+        description: "Operational scenario this override implements"
+        order_weight: 1100
+        choices:
+          - name: admin_shutdown
+            label: Admin Shutdown
+            description: "Administratively disable an interface or session"
+            color: "#F5B7B1"
+          - name: maintenance_mode
+            label: Maintenance Mode
+            description: "Device-wide maintenance state"
+            color: "#F9E79F"
+          - name: traffic_drain
+            label: Traffic Drain
+            description: "Drain traffic away ahead of planned work"
+            color: "#A9CCE3"
+          - name: emergency_bypass
+            label: Emergency Bypass
+            description: "Incident mitigation deviating from intent"
+            color: "#D98880"
+      - name: status
+        kind: Dropdown
+        description: "Lifecycle state of the override"
+        default_value: pending
+        order_weight: 1200
+        choices:
+          - name: pending
+            label: Pending
+            description: "Created, not yet applied to the device"
+            color: "#D5DBDB"
+          - name: active
+            label: Active
+            description: "Applied to the device, inside the validity window"
+            color: "#A9CCE3"
+          - name: reverted
+            label: Reverted
+            description: "Auto-revert converged the device back to intent"
+            color: "#A2D9CE"
+          - name: revert_failed
+            label: Revert Failed
+            description: "Auto-revert failed — device stuck in exception state"
+            color: "#D98880"
+          - name: cancelled
+            label: Cancelled
+            description: "Reverted early on request, before the window expired"
+            color: "#D7BDE2"
+      - name: reason
+        kind: Text
+        description: "Why this deviation is sanctioned (incident ref, work order)"
+        order_weight: 1300
+      - name: owner
+        kind: Text
+        optional: true
+        description: "Team or person accountable for this override"
+        order_weight: 1310
+      - name: origin
+        kind: Text
+        optional: true
+        description: "Change reference or ticket that introduced this override"
+        order_weight: 1320
+    relationships:
+      - name: device
+        peer: DcimDevice
+        optional: false
+        cardinality: one
+        kind: Attribute
+        description: "Device this override applies to"
+        order_weight: 1400
+      - name: window
+        peer: OverrideWindow
+        optional: false
+        cardinality: one
+        kind: Component
+        description: "Validity window (overrides are always time-bounded)"
+        order_weight: 1410
+      - name: actions
+        peer: OverrideAction
+        optional: true
+        cardinality: many
+        kind: Component
+        description: "Config changes applied under this override"
+        order_weight: 1420
+
+  - name: Window
+    namespace: Override
+    description: "Validity window of an operational override"
+    label: Override Window
+    icon: mdi:calendar-clock
+    display_labels:
+      - end_time__value
+    attributes:
+      - name: start_time
+        kind: DateTime
+        description: "When the override was applied"
+        order_weight: 1000
+      - name: end_time
+        kind: DateTime
+        description: "When the override expires — required; overrides are never open-ended"
+        order_weight: 1010
+      - name: auto_revert
+        kind: Boolean
+        default_value: true
+        description: "Automatically converge back to intent at end_time"
+        order_weight: 1020
+      - name: extension_count
+        kind: Number
+        default_value: 0
+        description: "How many times this window has been extended"
+        order_weight: 1030
+
+  - name: Action
+    namespace: Override
+    description: "A specific config change applied under an operational override"
+    label: Override Action
+    icon: mdi:file-swap-outline
+    display_labels:
+      - target_object__value
+    attributes:
+      - name: action_type
+        kind: Text
+        description: "Kind of change applied (e.g. gnmi_set)"
+        order_weight: 1000
+      - name: target_object
+        kind: Text
+        description: "Config path or object the change targets"
+        order_weight: 1010
+      - name: original_state
+        kind: JSON
+        optional: true
+        description: "State captured before the override (audit / manual fallback)"
+        order_weight: 1020
+      - name: override_state
+        kind: JSON
+        description: "State applied by the override"
+        order_weight: 1030

--- a/changelog/161.added.md
+++ b/changelog/161.added.md
@@ -1,0 +1,1 @@
+Operational intent schema: `OperationalOverride` (time-bounded, accountable deviation from as-built intent), `OverrideWindow` (required end time, auto-revert flag, extension counter), and `OverrideAction` (config change with before/after JSON for audit). Foundation for the override workflow and metrics (#63).

--- a/tests/unit/test_operational_override_schema.py
+++ b/tests/unit/test_operational_override_schema.py
@@ -1,0 +1,121 @@
+"""Unit tests for the operational intent schema (Issue #161).
+
+Validates the 3-object operational override model from the intent-model
+skill: OperationalOverride (the deviation), OverrideWindow (time bounds),
+and OverrideAction (the config change applied). Overrides are always
+time-bounded and auditable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCHEMA_PATH = Path(__file__).parents[2] / "backend" / "network_synapse" / "schemas" / "operational_override.yml"
+
+
+@pytest.fixture(scope="module")
+def nodes_by_kind() -> dict[str, dict]:
+    """Schema nodes keyed by their computed kind (namespace + name)."""
+    schema = yaml.safe_load(SCHEMA_PATH.read_text())
+    return {f"{n['namespace']}{n['name']}": n for n in schema.get("nodes", [])}
+
+
+def _attributes(node: dict) -> dict[str, dict]:
+    return {a["name"]: a for a in node.get("attributes", [])}
+
+
+def _relationships(node: dict) -> dict[str, dict]:
+    return {r["name"]: r for r in node.get("relationships", [])}
+
+
+@pytest.mark.unit
+class TestSchemaShape:
+    """The three operational intent objects exist."""
+
+    def test_all_three_kinds_defined(self, nodes_by_kind: dict) -> None:
+        """OperationalOverride, OverrideWindow, and OverrideAction are all present."""
+        missing = {"OperationalOverride", "OverrideWindow", "OverrideAction"} - set(nodes_by_kind)
+        assert not missing, f"missing kinds: {sorted(missing)}"
+
+    def test_schema_file_is_in_the_load_order(self) -> None:
+        """The loader must ship the new schema after the device schemas."""
+        from network_synapse.schemas.load_schemas import SCHEMA_LOAD_ORDER
+
+        names = [Path(entry).name for entry in SCHEMA_LOAD_ORDER]
+        assert "operational_override.yml" in names
+        assert names.index("operational_override.yml") > names.index("network_device.yml")
+
+
+@pytest.mark.unit
+class TestOperationalOverride:
+    """The override object itself."""
+
+    def test_override_type_covers_the_four_operational_scenarios(self, nodes_by_kind: dict) -> None:
+        """override_type is a dropdown with the four documented types."""
+        attr = _attributes(nodes_by_kind["OperationalOverride"])["override_type"]
+        assert attr["kind"] == "Dropdown"
+        choices = {c["name"] for c in attr["choices"]}
+        assert choices == {"admin_shutdown", "maintenance_mode", "traffic_drain", "emergency_bypass"}
+
+    def test_status_tracks_the_override_lifecycle(self, nodes_by_kind: dict) -> None:
+        """status covers pending through reverted/revert_failed/cancelled."""
+        attr = _attributes(nodes_by_kind["OperationalOverride"])["status"]
+        assert attr["kind"] == "Dropdown"
+        choices = {c["name"] for c in attr["choices"]}
+        assert {"pending", "active", "reverted", "revert_failed", "cancelled"} <= choices
+
+    def test_override_records_reason_owner_and_origin(self, nodes_by_kind: dict) -> None:
+        """Accountability metadata is mandatory for reason, present for owner/origin."""
+        attrs = _attributes(nodes_by_kind["OperationalOverride"])
+        assert attrs["reason"].get("optional") is not True, "reason must be required"
+        assert "owner" in attrs
+        assert "origin" in attrs
+
+    def test_override_is_bound_to_a_device_window_and_actions(self, nodes_by_kind: dict) -> None:
+        """Relationships: one device, one window, many actions."""
+        rels = _relationships(nodes_by_kind["OperationalOverride"])
+        assert rels["device"]["peer"] == "DcimDevice"
+        assert rels["device"]["cardinality"] == "one"
+        assert rels["window"]["peer"] == "OverrideWindow"
+        assert rels["window"]["cardinality"] == "one"
+        assert rels["actions"]["peer"] == "OverrideAction"
+        assert rels["actions"]["cardinality"] == "many"
+
+
+@pytest.mark.unit
+class TestOverrideWindow:
+    """Time bounds — overrides are always time-bounded."""
+
+    def test_end_time_is_required(self, nodes_by_kind: dict) -> None:
+        """An override without an end time is the anti-pattern the model forbids."""
+        attrs = _attributes(nodes_by_kind["OverrideWindow"])
+        assert attrs["end_time"]["kind"] == "DateTime"
+        assert attrs["end_time"].get("optional") is not True
+
+    def test_window_supports_auto_revert_and_extension_tracking(self, nodes_by_kind: dict) -> None:
+        """auto_revert defaults on; extension_count starts at zero."""
+        attrs = _attributes(nodes_by_kind["OverrideWindow"])
+        assert attrs["auto_revert"]["kind"] == "Boolean"
+        assert attrs["auto_revert"].get("default_value") is True
+        assert attrs["extension_count"]["kind"] == "Number"
+        assert attrs["extension_count"].get("default_value") == 0
+
+
+@pytest.mark.unit
+class TestOverrideAction:
+    """The specific config change, with before/after state for audit."""
+
+    def test_action_captures_original_and_override_state(self, nodes_by_kind: dict) -> None:
+        """original_state (audit/manual fallback) and override_state are JSON blobs."""
+        attrs = _attributes(nodes_by_kind["OverrideAction"])
+        assert attrs["original_state"]["kind"] == "JSON"
+        assert attrs["override_state"]["kind"] == "JSON"
+
+    def test_action_names_its_target(self, nodes_by_kind: dict) -> None:
+        """action_type and target_object identify what was changed."""
+        attrs = _attributes(nodes_by_kind["OverrideAction"])
+        assert "action_type" in attrs
+        assert "target_object" in attrs


### PR DESCRIPTION
## Summary

PR 1 of the override arc (#161 → #63 → #68 → #64): the 3-object operational intent model from the intent-model skill, as Infrahub schema.

| Kind | Purpose | Notes |
|---|---|---|
| `OperationalOverride` | Sanctioned, time-bounded deviation from as-built intent | 4 override types, 5 lifecycle statuses, **required `reason`**, owner/origin metadata, device + window + actions relationships |
| `OverrideWindow` | Validity bounds | `end_time` **required** — "not setting an end time" is the documented anti-pattern; `auto_revert` defaults on; `extension_count` tracks chronic extensions |
| `OverrideAction` | The config change applied | `original_state` / `override_state` JSON for audit |

Design notes (agreed in #161):
- Overrides live in **Infrahub** so drift detection, SuzieQ validation (#64), and the posture writer can query them.
- `original_state` is captured for audit and manual fallback only — the upcoming workflow's auto-revert converges the device to *current* SoT intent, not the snapshot, so pre-override drift isn't resurrected.
- Window and actions are `Component` relationships (owned by, and deleted with, their override).

## Test plan

- [x] TDD: `tests/unit/test_operational_override_schema.py` written first (red) — 10 tests over kind presence, dropdown choices, required fields, defaults, relationship shape, and loader inclusion/ordering
- [x] Full unit suite: 385 passed; lint + yamllint clean
- [ ] CI Schema Validation loads the new kinds into a fresh Infrahub (authoritative check)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking operational overrides with a defined window, status, reason, ownership, and related change actions.
  * Introduced time-bounded override details, including automatic revert behavior and extension tracking.

* **Tests**
  * Added coverage to verify the new override schema structure and required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->