### PR TITLE
feat: operational override workflow, signals, and metrics (#48, #49, #63)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -159,7 +159,7 @@
         "filename": "backend/network_synapse/infrahub/client.py",
         "hashed_secret": "62f333b55a66d31d0519d11862a8da5aad215e2f",
         "is_verified": false,
-        "line_number": 205
+        "line_number": 232
       }
     ],
     "backend/network_synapse/infrahub/resource_manager.py": [
@@ -273,5 +273,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-05T05:14:48Z"
+  "generated_at": "2026-07-08T14:06:43Z"
 }

--- a/backend/network_synapse/infrahub/client.py
+++ b/backend/network_synapse/infrahub/client.py
@@ -95,6 +95,33 @@ mutation UpdateDeviceStatus($data: DcimDeviceUpdateInput!) {
 
 VALID_DEVICE_STATUSES: frozenset[str] = frozenset({"active", "provisioning", "maintenance", "drained"})
 
+QUERY_OVERRIDE = """
+query GetOverride($name: String!) {
+    OperationalOverride(name__value: $name) {
+        edges {
+            node {
+                id
+                status { value }
+            }
+        }
+    }
+}
+"""
+
+MUTATION_UPDATE_OVERRIDE_STATUS = """
+mutation UpdateOverrideStatus($data: OperationalOverrideUpdateInput!) {
+    OperationalOverrideUpdate(data: $data) {
+        ok
+        object {
+            id
+            display_label
+        }
+    }
+}
+"""
+
+VALID_OVERRIDE_STATUSES: frozenset[str] = frozenset({"pending", "active", "reverted", "revert_failed", "cancelled"})
+
 QUERY_DEVICE_BGP_SESSIONS = """
 query GetDeviceBGPSessions($device_ids: [ID!]) {
     RoutingBGPSession(device__ids: $device_ids) {
@@ -403,6 +430,48 @@ class InfrahubConfigClient:
             raise RuntimeError(f"Failed to update status for device '{hostname}': {result}")
 
         return device
+
+    def update_override_status(self, override_name: str, new_status: str) -> str:
+        """Update an OperationalOverride's lifecycle status via GraphQL mutation.
+
+        Resolves the override ID via its unique name, then issues an
+        OperationalOverrideUpdate mutation.
+
+        Args:
+            override_name: Unique name of the OperationalOverride node.
+            new_status: Target status. Must be one of: pending, active,
+                reverted, revert_failed, cancelled.
+
+        Returns:
+            The override's status *before* the update (for audit logging).
+
+        Raises:
+            ValueError: If new_status is not a valid override status.
+            RuntimeError: If the override does not exist or the mutation fails.
+        """
+        if new_status not in VALID_OVERRIDE_STATUSES:
+            msg = (
+                f"Invalid override status '{new_status}'. Must be one of: {', '.join(sorted(VALID_OVERRIDE_STATUSES))}"
+            )
+            raise ValueError(msg)
+
+        lookup = self._graphql(QUERY_OVERRIDE, variables={"name": override_name})
+        edges = lookup.get("OperationalOverride", {}).get("edges", [])
+        if not edges:
+            raise RuntimeError(f"Override '{override_name}' not found in Infrahub")
+        node = edges[0]["node"]
+        previous_status = node["status"]["value"]
+
+        result = self._graphql(
+            MUTATION_UPDATE_OVERRIDE_STATUS,
+            variables={"data": {"id": node["id"], "status": {"value": new_status}}},
+        )
+
+        update_result = result.get("OperationalOverrideUpdate", {})
+        if not update_result.get("ok"):
+            raise RuntimeError(f"Failed to update status for override '{override_name}': {result}")
+
+        return previous_status
 
     def execute_transform(self, transform_name: str, variables: dict[str, Any] | None = None) -> str:
         """Execute an Infrahub Python transform and return the result.

--- a/backend/network_synapse/schemas/load_schemas.py
+++ b/backend/network_synapse/schemas/load_schemas.py
@@ -55,6 +55,7 @@ SCHEMA_LOAD_BATCHES = [
         "backend/network_synapse/schemas/network_device.yml",
         "backend/network_synapse/schemas/network_interface.yml",
         "backend/network_synapse/schemas/bgp_session.yml",
+        "backend/network_synapse/schemas/operational_override.yml",
     ],
 ]
 

--- a/backend/network_synapse/schemas/operational_override.yml
+++ b/backend/network_synapse/schemas/operational_override.yml
@@ -1,0 +1,172 @@
+# Infrahub schema: Operational Intent — time-bounded overrides (Issue #161)
+#
+# Implements the 3-object operational intent model (see the intent-model
+# skill): a deviation from as-built intent that is always time-bounded,
+# accountable, and auditable.
+#
+#   OperationalOverride — the sanctioned deviation (what + why + who)
+#   OverrideWindow      — the time bounds (end_time required, auto-revert)
+#   OverrideAction      — the config change applied (before/after JSON)
+#
+# original_state is captured for audit and manual fallback; the
+# OperationalOverrideWorkflow's auto-revert converges the device to the
+# *current* SoT intent, not this snapshot (agreed in #161).
+#
+# Dependencies: base dcim schema (DcimDevice) must be loaded first.
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+nodes:
+  - name: Override
+    namespace: Operational
+    description: "Time-bounded, sanctioned deviation from as-built intent"
+    label: Operational Override
+    icon: mdi:clock-alert-outline
+    default_filter: name__value
+    display_labels:
+      - name__value
+    order_by:
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+        description: "Short identifier for this override (e.g. leaf01-drain-2026-07-06)"
+        order_weight: 1000
+      - name: override_type
+        kind: Dropdown
+        description: "Operational scenario this override implements"
+        order_weight: 1100
+        choices:
+          - name: admin_shutdown
+            label: Admin Shutdown
+            description: "Administratively disable an interface or session"
+            color: "#F5B7B1"
+          - name: maintenance_mode
+            label: Maintenance Mode
+            description: "Device-wide maintenance state"
+            color: "#F9E79F"
+          - name: traffic_drain
+            label: Traffic Drain
+            description: "Drain traffic away ahead of planned work"
+            color: "#A9CCE3"
+          - name: emergency_bypass
+            label: Emergency Bypass
+            description: "Incident mitigation deviating from intent"
+            color: "#D98880"
+      - name: status
+        kind: Dropdown
+        description: "Lifecycle state of the override"
+        default_value: pending
+        order_weight: 1200
+        choices:
+          - name: pending
+            label: Pending
+            description: "Created, not yet applied to the device"
+            color: "#D5DBDB"
+          - name: active
+            label: Active
+            description: "Applied to the device, inside the validity window"
+            color: "#A9CCE3"
+          - name: reverted
+            label: Reverted
+            description: "Auto-revert converged the device back to intent"
+            color: "#A2D9CE"
+          - name: revert_failed
+            label: Revert Failed
+            description: "Auto-revert failed — device stuck in exception state"
+            color: "#D98880"
+          - name: cancelled
+            label: Cancelled
+            description: "Reverted early on request, before the window expired"
+            color: "#D7BDE2"
+      - name: reason
+        kind: Text
+        description: "Why this deviation is sanctioned (incident ref, work order)"
+        order_weight: 1300
+      - name: owner
+        kind: Text
+        optional: true
+        description: "Team or person accountable for this override"
+        order_weight: 1310
+      - name: origin
+        kind: Text
+        optional: true
+        description: "Change reference or ticket that introduced this override"
+        order_weight: 1320
+    relationships:
+      - name: device
+        peer: DcimDevice
+        optional: false
+        cardinality: one
+        kind: Attribute
+        description: "Device this override applies to"
+        order_weight: 1400
+      - name: window
+        peer: OverrideWindow
+        optional: false
+        cardinality: one
+        kind: Component
+        description: "Validity window (overrides are always time-bounded)"
+        order_weight: 1410
+      - name: actions
+        peer: OverrideAction
+        optional: true
+        cardinality: many
+        kind: Component
+        description: "Config changes applied under this override"
+        order_weight: 1420
+
+  - name: Window
+    namespace: Override
+    description: "Validity window of an operational override"
+    label: Override Window
+    icon: mdi:calendar-clock
+    display_labels:
+      - end_time__value
+    attributes:
+      - name: start_time
+        kind: DateTime
+        description: "When the override was applied"
+        order_weight: 1000
+      - name: end_time
+        kind: DateTime
+        description: "When the override expires — required; overrides are never open-ended"
+        order_weight: 1010
+      - name: auto_revert
+        kind: Boolean
+        default_value: true
+        description: "Automatically converge back to intent at end_time"
+        order_weight: 1020
+      - name: extension_count
+        kind: Number
+        default_value: 0
+        description: "How many times this window has been extended"
+        order_weight: 1030
+
+  - name: Action
+    namespace: Override
+    description: "A specific config change applied under an operational override"
+    label: Override Action
+    icon: mdi:file-swap-outline
+    display_labels:
+      - target_object__value
+    attributes:
+      - name: action_type
+        kind: Text
+        description: "Kind of change applied (e.g. gnmi_set)"
+        order_weight: 1000
+      - name: target_object
+        kind: Text
+        description: "Config path or object the change targets"
+        order_weight: 1010
+      - name: original_state
+        kind: JSON
+        optional: true
+        description: "State captured before the override (audit / manual fallback)"
+        order_weight: 1020
+      - name: override_state
+        kind: JSON
+        description: "State applied by the override"
+        order_weight: 1030

--- a/changelog/161.added.md
+++ b/changelog/161.added.md
@@ -1,0 +1,1 @@
+Operational intent schema: `OperationalOverride` (time-bounded, accountable deviation from as-built intent), `OverrideWindow` (required end time, auto-revert flag, extension counter), and `OverrideAction` (config change with before/after JSON for audit). Foundation for the override workflow and metrics (#63).

--- a/changelog/48.added.md
+++ b/changelog/48.added.md
@@ -1,0 +1,1 @@
+OperationalOverrideWorkflow: applies a time-bounded override via gNMI, waits on a durable Temporal timer, checks reversion safety, and auto-reverts the device to the current SoT intent.

--- a/changelog/49.added.md
+++ b/changelog/49.added.md
@@ -1,0 +1,1 @@
+Signal handling for operational overrides: `terminate_early` (incident resolved) and `extend_window` (incident ongoing) with extension-count tracking.

--- a/changelog/63.added.md
+++ b/changelog/63.added.md
@@ -1,0 +1,1 @@
+Operational intent metrics on the worker /metrics endpoint: `override_active_count`, `override_auto_revert_success_total`, `override_auto_revert_failure_total`, `override_mean_duration_seconds`, `override_extension_count_total`, `override_state_validation_result`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,10 @@ _recorded_status_updates: list[tuple[str, str]] = []
 _recorded_audit_events: list[tuple[str, str, str]] = []
 _recorded_store_backup_calls: list[tuple[str, str]] = []
 _recorded_rollback_calls: list[tuple[str, str, str]] = []
+_recorded_override_status_updates: list[tuple[str, str]] = []
+_recorded_override_revert_calls: list[tuple[str, str, float]] = []
+_recorded_override_revert_failures: list[tuple[str, str]] = []
+_recorded_override_extensions: list[tuple[str, int]] = []
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +45,10 @@ def _reset_workflow_spies() -> None:
     _recorded_audit_events.clear()
     _recorded_store_backup_calls.clear()
     _recorded_rollback_calls.clear()
+    _recorded_override_status_updates.clear()
+    _recorded_override_revert_calls.clear()
+    _recorded_override_revert_failures.clear()
+    _recorded_override_extensions.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_infrahub_client.py
+++ b/tests/unit/test_infrahub_client.py
@@ -325,6 +325,58 @@ class TestUpdateDeviceStatus:
 
 
 # ---------------------------------------------------------------------------
+# update_override_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUpdateOverrideStatus:
+    """Test the OperationalOverride status update mutation (Issue #48)."""
+
+    def _override_lookup(self, override_id: str = "override-id", status: str = "active") -> dict:
+        return {"OperationalOverride": {"edges": [{"node": {"id": override_id, "status": {"value": status}}}]}}
+
+    def test_invalid_status_raises_value_error(self):
+        client = InfrahubConfigClient(url="http://test:8000", token="tok")
+        with pytest.raises(ValueError, match="Invalid override status 'bogus'"):
+            client.update_override_status("leaf01-drain", "bogus")
+
+    def test_successful_update_returns_previous_status(self):
+        client = InfrahubConfigClient(url="http://test:8000", token="tok")
+        responses = [
+            self._override_lookup(status="active"),
+            {"OperationalOverrideUpdate": {"ok": True}},
+        ]
+        with patch.object(client, "_graphql", side_effect=responses) as mock_gql:
+            previous = client.update_override_status("leaf01-drain", "reverted")
+
+        assert previous == "active"
+        assert mock_gql.call_count == 2
+        variables = mock_gql.call_args.kwargs["variables"]
+        assert variables == {"data": {"id": "override-id", "status": {"value": "reverted"}}}
+
+    def test_unknown_override_raises_runtime_error(self):
+        client = InfrahubConfigClient(url="http://test:8000", token="tok")
+        with (
+            patch.object(client, "_graphql", return_value={"OperationalOverride": {"edges": []}}),
+            pytest.raises(RuntimeError, match="Override 'ghost-drain' not found"),
+        ):
+            client.update_override_status("ghost-drain", "reverted")
+
+    def test_failed_mutation_raises_runtime_error(self):
+        client = InfrahubConfigClient(url="http://test:8000", token="tok")
+        responses = [
+            self._override_lookup(),
+            {"OperationalOverrideUpdate": {"ok": False}},
+        ]
+        with (
+            patch.object(client, "_graphql", side_effect=responses),
+            pytest.raises(RuntimeError, match="Failed to update status for override"),
+        ):
+            client.update_override_status("leaf01-drain", "cancelled")
+
+
+# ---------------------------------------------------------------------------
 # execute_transform
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_operational_override_schema.py
+++ b/tests/unit/test_operational_override_schema.py
@@ -1,0 +1,121 @@
+"""Unit tests for the operational intent schema (Issue #161).
+
+Validates the 3-object operational override model from the intent-model
+skill: OperationalOverride (the deviation), OverrideWindow (time bounds),
+and OverrideAction (the config change applied). Overrides are always
+time-bounded and auditable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCHEMA_PATH = Path(__file__).parents[2] / "backend" / "network_synapse" / "schemas" / "operational_override.yml"
+
+
+@pytest.fixture(scope="module")
+def nodes_by_kind() -> dict[str, dict]:
+    """Schema nodes keyed by their computed kind (namespace + name)."""
+    schema = yaml.safe_load(SCHEMA_PATH.read_text())
+    return {f"{n['namespace']}{n['name']}": n for n in schema.get("nodes", [])}
+
+
+def _attributes(node: dict) -> dict[str, dict]:
+    return {a["name"]: a for a in node.get("attributes", [])}
+
+
+def _relationships(node: dict) -> dict[str, dict]:
+    return {r["name"]: r for r in node.get("relationships", [])}
+
+
+@pytest.mark.unit
+class TestSchemaShape:
+    """The three operational intent objects exist."""
+
+    def test_all_three_kinds_defined(self, nodes_by_kind: dict) -> None:
+        """OperationalOverride, OverrideWindow, and OverrideAction are all present."""
+        missing = {"OperationalOverride", "OverrideWindow", "OverrideAction"} - set(nodes_by_kind)
+        assert not missing, f"missing kinds: {sorted(missing)}"
+
+    def test_schema_file_is_in_the_load_order(self) -> None:
+        """The loader must ship the new schema after the device schemas."""
+        from network_synapse.schemas.load_schemas import SCHEMA_LOAD_ORDER
+
+        names = [Path(entry).name for entry in SCHEMA_LOAD_ORDER]
+        assert "operational_override.yml" in names
+        assert names.index("operational_override.yml") > names.index("network_device.yml")
+
+
+@pytest.mark.unit
+class TestOperationalOverride:
+    """The override object itself."""
+
+    def test_override_type_covers_the_four_operational_scenarios(self, nodes_by_kind: dict) -> None:
+        """override_type is a dropdown with the four documented types."""
+        attr = _attributes(nodes_by_kind["OperationalOverride"])["override_type"]
+        assert attr["kind"] == "Dropdown"
+        choices = {c["name"] for c in attr["choices"]}
+        assert choices == {"admin_shutdown", "maintenance_mode", "traffic_drain", "emergency_bypass"}
+
+    def test_status_tracks_the_override_lifecycle(self, nodes_by_kind: dict) -> None:
+        """status covers pending through reverted/revert_failed/cancelled."""
+        attr = _attributes(nodes_by_kind["OperationalOverride"])["status"]
+        assert attr["kind"] == "Dropdown"
+        choices = {c["name"] for c in attr["choices"]}
+        assert {"pending", "active", "reverted", "revert_failed", "cancelled"} <= choices
+
+    def test_override_records_reason_owner_and_origin(self, nodes_by_kind: dict) -> None:
+        """Accountability metadata is mandatory for reason, present for owner/origin."""
+        attrs = _attributes(nodes_by_kind["OperationalOverride"])
+        assert attrs["reason"].get("optional") is not True, "reason must be required"
+        assert "owner" in attrs
+        assert "origin" in attrs
+
+    def test_override_is_bound_to_a_device_window_and_actions(self, nodes_by_kind: dict) -> None:
+        """Relationships: one device, one window, many actions."""
+        rels = _relationships(nodes_by_kind["OperationalOverride"])
+        assert rels["device"]["peer"] == "DcimDevice"
+        assert rels["device"]["cardinality"] == "one"
+        assert rels["window"]["peer"] == "OverrideWindow"
+        assert rels["window"]["cardinality"] == "one"
+        assert rels["actions"]["peer"] == "OverrideAction"
+        assert rels["actions"]["cardinality"] == "many"
+
+
+@pytest.mark.unit
+class TestOverrideWindow:
+    """Time bounds — overrides are always time-bounded."""
+
+    def test_end_time_is_required(self, nodes_by_kind: dict) -> None:
+        """An override without an end time is the anti-pattern the model forbids."""
+        attrs = _attributes(nodes_by_kind["OverrideWindow"])
+        assert attrs["end_time"]["kind"] == "DateTime"
+        assert attrs["end_time"].get("optional") is not True
+
+    def test_window_supports_auto_revert_and_extension_tracking(self, nodes_by_kind: dict) -> None:
+        """auto_revert defaults on; extension_count starts at zero."""
+        attrs = _attributes(nodes_by_kind["OverrideWindow"])
+        assert attrs["auto_revert"]["kind"] == "Boolean"
+        assert attrs["auto_revert"].get("default_value") is True
+        assert attrs["extension_count"]["kind"] == "Number"
+        assert attrs["extension_count"].get("default_value") == 0
+
+
+@pytest.mark.unit
+class TestOverrideAction:
+    """The specific config change, with before/after state for audit."""
+
+    def test_action_captures_original_and_override_state(self, nodes_by_kind: dict) -> None:
+        """original_state (audit/manual fallback) and override_state are JSON blobs."""
+        attrs = _attributes(nodes_by_kind["OverrideAction"])
+        assert attrs["original_state"]["kind"] == "JSON"
+        assert attrs["override_state"]["kind"] == "JSON"
+
+    def test_action_names_its_target(self, nodes_by_kind: dict) -> None:
+        """action_type and target_object identify what was changed."""
+        attrs = _attributes(nodes_by_kind["OverrideAction"])
+        assert "action_type" in attrs
+        assert "target_object" in attrs

--- a/tests/unit/test_operational_override_workflow.py
+++ b/tests/unit/test_operational_override_workflow.py
@@ -1,0 +1,368 @@
+"""Unit tests for the OperationalOverrideWorkflow (Issues #48, #49).
+
+Tests cover:
+- Window expiry: apply, durable timer, safety check, revert to current SoT intent
+- Early termination via the terminate_early signal (incident resolved)
+- Window extension via the extend_window signal (incident ongoing)
+- Apply failure aborts before the override is marked active
+- Revert failure and unsafe reversion mark the override revert_failed
+- Input validation (duration must be positive)
+"""
+
+from __future__ import annotations
+
+import pytest
+from temporalio import activity
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from synapse_workers.workflows.operational_override_workflow import (
+    OperationalOverrideInput,
+    OperationalOverrideWorkflow,
+)
+from tests.conftest import (
+    _recorded_audit_events,
+    _recorded_override_extensions,
+    _recorded_override_revert_calls,
+    _recorded_override_revert_failures,
+    _recorded_override_status_updates,
+    _recorded_store_backup_calls,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+OVERRIDE_NAME = "leaf01-drain-2026-07-06"
+DEVICE = "leaf01"
+IP = "172.20.20.2"
+OVERRIDE_CONFIG = '{"srl_nokia-interfaces:interface": [{"name": "ethernet-1/1", "admin-state": "disable"}]}'
+ORIGINAL_CONFIG = '{"srl_nokia-interfaces:interface": [{"name": "ethernet-1/1", "admin-state": "enable"}]}'
+INTENDED_CONFIG = '{"srl_nokia-interfaces:interface": [{"name": "ethernet-1/1", "admin-state": "enable", "mtu": 9214}]}'
+
+
+# ---------------------------------------------------------------------------
+# Mock activities
+# ---------------------------------------------------------------------------
+
+
+@activity.defn(name="fetch_running_config")
+async def mock_fetch_running_config(
+    device_hostname: str,
+    ip_address: str,
+    username: str = "admin",
+    password: str = "NokiaSrl1!",  # noqa: S107
+    port: int = 57400,
+) -> str:
+    return ORIGINAL_CONFIG
+
+
+@activity.defn(name="store_backup")
+async def mock_store_backup(device_hostname: str, config: str) -> None:
+    _recorded_store_backup_calls.append((device_hostname, config))
+
+
+@activity.defn(name="apply_override_config")
+async def mock_apply(device_hostname: str, ip_address: str, override_config_json: str) -> bool:
+    return True
+
+
+@activity.defn(name="apply_override_config")
+async def mock_apply_fail(device_hostname: str, ip_address: str, override_config_json: str) -> bool:
+    raise ApplicationError("gNMI SET failed", non_retryable=True)
+
+
+@activity.defn(name="update_override_status")
+async def mock_update_override_status(override_name: str, status: str) -> None:
+    _recorded_override_status_updates.append((override_name, status))
+
+
+@activity.defn(name="check_reversion_safety")
+async def mock_safety_ok(device_hostname: str, ip_address: str) -> bool:
+    return True
+
+
+@activity.defn(name="check_reversion_safety")
+async def mock_safety_unsafe(device_hostname: str, ip_address: str) -> bool:
+    return False
+
+
+@activity.defn(name="fetch_device_config")
+async def mock_fetch_device_config(device_hostname: str) -> dict:
+    return {"hostname": device_hostname, "status": "active", "bgp": {}, "interfaces": {"interfaces": []}}
+
+
+@activity.defn(name="render_intended_config")
+async def mock_render_intended_config(interface_data: dict) -> str:
+    return INTENDED_CONFIG
+
+
+@activity.defn(name="revert_override_config")
+async def mock_revert(device_hostname: str, ip_address: str, intended_config_json: str, active_seconds: float) -> bool:
+    _recorded_override_revert_calls.append((device_hostname, intended_config_json, active_seconds))
+    return True
+
+
+@activity.defn(name="revert_override_config")
+async def mock_revert_fail(
+    device_hostname: str, ip_address: str, intended_config_json: str, active_seconds: float
+) -> bool:
+    raise ApplicationError("gNMI SET failed during revert", non_retryable=True)
+
+
+@activity.defn(name="record_override_revert_failure")
+async def mock_record_revert_failure(device_hostname: str, reason: str) -> None:
+    _recorded_override_revert_failures.append((device_hostname, reason))
+
+
+@activity.defn(name="record_override_extension")
+async def mock_record_extension(override_name: str, additional_seconds: int) -> None:
+    _recorded_override_extensions.append((override_name, additional_seconds))
+
+
+@activity.defn(name="log_audit_event")
+async def mock_log_audit(event_type: str, device_hostname: str, details: str) -> None:
+    _recorded_audit_events.append((event_type, device_hostname, details))
+
+
+def _activities(apply=mock_apply, safety=mock_safety_ok, revert=mock_revert) -> list:
+    return [
+        mock_fetch_running_config,
+        mock_store_backup,
+        apply,
+        mock_update_override_status,
+        safety,
+        mock_fetch_device_config,
+        mock_render_intended_config,
+        revert,
+        mock_record_revert_failure,
+        mock_record_extension,
+        mock_log_audit,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_input(duration_seconds: int = 3600) -> OperationalOverrideInput:
+    return OperationalOverrideInput(
+        override_name=OVERRIDE_NAME,
+        device_hostname=DEVICE,
+        ip_address=IP,
+        override_type="traffic_drain",
+        override_config_json=OVERRIDE_CONFIG,
+        reason="fibre outage INC-4242",
+        operator="anton",
+        duration_seconds=duration_seconds,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_override_expires_and_reverts_to_current_intent() -> None:
+    """Window expiry: apply, wait out the timer, revert to current SoT intent."""
+    async with (
+        await WorkflowEnvironment.start_time_skipping() as env,
+        Worker(
+            env.client,
+            task_queue="test-override",
+            workflows=[OperationalOverrideWorkflow],
+            activities=_activities(),
+        ),
+    ):
+        result = await env.client.execute_workflow(
+            OperationalOverrideWorkflow.run,
+            args=[_make_input(duration_seconds=3600)],
+            id=f"override-test-expiry-{DEVICE}",
+            task_queue="test-override",
+        )
+        assert result == "OVERRIDE_REVERTED"
+
+    # Lifecycle in Infrahub: active while applied, reverted at the end.
+    assert _recorded_override_status_updates == [(OVERRIDE_NAME, "active"), (OVERRIDE_NAME, "reverted")]
+    # Original state was captured before the override was applied.
+    assert (DEVICE, ORIGINAL_CONFIG) in _recorded_store_backup_calls
+    # Auto-revert converges to the *current* SoT intent, not the snapshot (#161).
+    assert len(_recorded_override_revert_calls) == 1
+    device, config, active_seconds = _recorded_override_revert_calls[0]
+    assert device == DEVICE
+    assert config == INTENDED_CONFIG
+    assert active_seconds >= 3600
+    audit_types = [event[0] for event in _recorded_audit_events]
+    assert "OVERRIDE_INITIATED" in audit_types
+    assert "OVERRIDE_APPLIED" in audit_types
+    assert "OVERRIDE_REVERTED" in audit_types
+
+
+@pytest.mark.asyncio
+async def test_terminate_early_signal_cancels_override() -> None:
+    """Early termination (incident resolved): revert immediately, mark cancelled."""
+    async with (
+        await WorkflowEnvironment.start_time_skipping() as env,
+        Worker(
+            env.client,
+            task_queue="test-override",
+            workflows=[OperationalOverrideWorkflow],
+            activities=_activities(),
+        ),
+    ):
+        handle = await env.client.start_workflow(
+            OperationalOverrideWorkflow.run,
+            args=[_make_input(duration_seconds=86400)],
+            id=f"override-test-early-{DEVICE}",
+            task_queue="test-override",
+        )
+        await handle.signal(OperationalOverrideWorkflow.terminate_early, "incident resolved")
+        result = await handle.result()
+        assert result == "OVERRIDE_CANCELLED"
+
+    assert _recorded_override_status_updates == [(OVERRIDE_NAME, "active"), (OVERRIDE_NAME, "cancelled")]
+    assert len(_recorded_override_revert_calls) == 1
+    audit_types = [event[0] for event in _recorded_audit_events]
+    assert "OVERRIDE_TERMINATED_EARLY" in audit_types
+
+
+@pytest.mark.asyncio
+async def test_extend_window_signal_extends_and_counts() -> None:
+    """Window extension (incident ongoing): revert only after the extended window."""
+    async with (
+        await WorkflowEnvironment.start_time_skipping() as env,
+        Worker(
+            env.client,
+            task_queue="test-override",
+            workflows=[OperationalOverrideWorkflow],
+            activities=_activities(),
+        ),
+    ):
+        handle = await env.client.start_workflow(
+            OperationalOverrideWorkflow.run,
+            args=[_make_input(duration_seconds=3600)],
+            id=f"override-test-extend-{DEVICE}",
+            task_queue="test-override",
+        )
+        await handle.signal(OperationalOverrideWorkflow.extend_window, args=[7200, "works overrunning"])
+        result = await handle.result()
+        assert result == "OVERRIDE_REVERTED"
+
+    # Extension was tracked (metric activity) and audited.
+    assert _recorded_override_extensions == [(OVERRIDE_NAME, 7200)]
+    audit_types = [event[0] for event in _recorded_audit_events]
+    assert "OVERRIDE_EXTENDED" in audit_types
+    # The override stayed active through the extended window before reverting.
+    assert len(_recorded_override_revert_calls) == 1
+    active_seconds = _recorded_override_revert_calls[0][2]
+    assert active_seconds >= 3600 + 7200
+
+
+@pytest.mark.asyncio
+async def test_apply_failure_aborts_before_active() -> None:
+    """If the override config cannot be applied, fail without marking it active."""
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue="test-override",
+            workflows=[OperationalOverrideWorkflow],
+            activities=_activities(apply=mock_apply_fail),
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                OperationalOverrideWorkflow.run,
+                args=[_make_input()],
+                id=f"override-test-apply-fail-{DEVICE}",
+                task_queue="test-override",
+            )
+        assert "apply failed" in str(exc_info.value.cause).lower()
+
+    assert _recorded_override_status_updates == []
+    assert _recorded_override_revert_calls == []
+    audit_types = [event[0] for event in _recorded_audit_events]
+    assert "OVERRIDE_APPLY_FAILED" in audit_types
+
+
+@pytest.mark.asyncio
+async def test_revert_failure_marks_revert_failed() -> None:
+    """If the revert deploy fails, record the failure and mark revert_failed."""
+    async with (
+        await WorkflowEnvironment.start_time_skipping() as env,
+        Worker(
+            env.client,
+            task_queue="test-override",
+            workflows=[OperationalOverrideWorkflow],
+            activities=_activities(revert=mock_revert_fail),
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                OperationalOverrideWorkflow.run,
+                args=[_make_input(duration_seconds=60)],
+                id=f"override-test-revert-fail-{DEVICE}",
+                task_queue="test-override",
+            )
+        assert "revert failed" in str(exc_info.value.cause).lower()
+
+    assert _recorded_override_status_updates == [(OVERRIDE_NAME, "active"), (OVERRIDE_NAME, "revert_failed")]
+    assert len(_recorded_override_revert_failures) == 1
+    audit_types = [event[0] for event in _recorded_audit_events]
+    assert "OVERRIDE_REVERT_FAILED" in audit_types
+
+
+@pytest.mark.asyncio
+async def test_unsafe_reversion_marks_revert_failed_without_deploying() -> None:
+    """If the safety check fails, do not touch the device; mark revert_failed."""
+    async with (
+        await WorkflowEnvironment.start_time_skipping() as env,
+        Worker(
+            env.client,
+            task_queue="test-override",
+            workflows=[OperationalOverrideWorkflow],
+            activities=_activities(safety=mock_safety_unsafe),
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                OperationalOverrideWorkflow.run,
+                args=[_make_input(duration_seconds=60)],
+                id=f"override-test-unsafe-{DEVICE}",
+                task_queue="test-override",
+            )
+        assert "safety" in str(exc_info.value.cause).lower()
+
+    assert _recorded_override_status_updates == [(OVERRIDE_NAME, "active"), (OVERRIDE_NAME, "revert_failed")]
+    assert _recorded_override_revert_calls == []
+    assert len(_recorded_override_revert_failures) == 1
+    audit_types = [event[0] for event in _recorded_audit_events]
+    assert "OVERRIDE_REVERT_UNSAFE" in audit_types
+
+
+@pytest.mark.asyncio
+async def test_non_positive_duration_rejected() -> None:
+    """Overrides are always time-bounded: duration_seconds must be > 0."""
+    async with (
+        await WorkflowEnvironment.start_local() as env,
+        Worker(
+            env.client,
+            task_queue="test-override",
+            workflows=[OperationalOverrideWorkflow],
+            activities=_activities(),
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                OperationalOverrideWorkflow.run,
+                args=[_make_input(duration_seconds=0)],
+                id=f"override-test-zero-duration-{DEVICE}",
+                task_queue="test-override",
+            )
+        assert "duration_seconds" in str(exc_info.value.cause)
+
+    assert _recorded_override_status_updates == []

--- a/tests/unit/test_override_activities.py
+++ b/tests/unit/test_override_activities.py
@@ -1,0 +1,173 @@
+"""Unit tests for the operational override activities and metrics (Issue #63).
+
+Covers the override metric contract (six metrics from the issue spec) and
+the emissions wired into the override activities. Metrics are emitted from
+activities only — never from workflow code, which Temporal replays.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from synapse_workers import metrics
+from synapse_workers.activities import override_activities as oa
+
+# Metric name -> prometheus type, per Issue #63
+EXPECTED_METRICS = {
+    "override_active_count": "gauge",
+    "override_auto_revert_success": "counter",
+    "override_auto_revert_failure": "counter",
+    "override_mean_duration_seconds": "histogram",
+    "override_extension_count": "counter",
+    "override_state_validation_result": "gauge",
+}
+
+
+def _sample(name: str, labels: dict[str, str] | None = None) -> float | None:
+    return metrics.REGISTRY.get_sample_value(name, labels or {})
+
+
+@pytest.mark.unit
+class TestOverrideMetricContract:
+    """All six Issue #63 metrics exist in the worker registry with correct types."""
+
+    def test_all_six_metrics_registered_with_expected_types(self) -> None:
+        """The registry exposes every metric from the issue spec."""
+        families = {f.name: f.type for f in metrics.REGISTRY.collect()}
+        for name, metric_type in EXPECTED_METRICS.items():
+            assert families.get(name) == metric_type, f"{name}: expected {metric_type}, got {families.get(name)}"
+
+
+@pytest.mark.unit
+class TestApplyOverrideConfig:
+    """apply_override_config deploys via gNMI and tracks the active gauge."""
+
+    def test_successful_apply_increments_active_gauge(self) -> None:
+        before = _sample("override_active_count") or 0
+
+        with patch.object(oa, "deploy_config_via_gnmi", new=AsyncMock(return_value=True)):
+            result = asyncio.run(oa.apply_override_config("leaf01", "172.20.20.2", "{}"))
+
+        assert result is True
+        assert _sample("override_active_count") == before + 1
+
+    def test_failed_apply_raises_without_touching_gauge(self) -> None:
+        before = _sample("override_active_count") or 0
+
+        with (
+            patch.object(oa, "deploy_config_via_gnmi", new=AsyncMock(return_value=False)),
+            pytest.raises(RuntimeError, match="apply failed"),
+        ):
+            asyncio.run(oa.apply_override_config("leaf01", "172.20.20.2", "{}"))
+
+        assert _sample("override_active_count") == before
+
+
+@pytest.mark.unit
+class TestRevertOverrideConfig:
+    """revert_override_config converges to intent and records revert metrics."""
+
+    def test_successful_revert_counts_success_and_observes_duration(self) -> None:
+        before_gauge = _sample("override_active_count") or 0
+        before_success = _sample("override_auto_revert_success_total") or 0
+        before_hist_count = _sample("override_mean_duration_seconds_count") or 0
+        before_hist_sum = _sample("override_mean_duration_seconds_sum") or 0
+
+        with patch.object(oa, "deploy_config_via_gnmi", new=AsyncMock(return_value=True)):
+            result = asyncio.run(oa.revert_override_config("leaf01", "172.20.20.2", "{}", 3600.0))
+
+        assert result is True
+        assert _sample("override_active_count") == before_gauge - 1
+        assert _sample("override_auto_revert_success_total") == before_success + 1
+        assert _sample("override_mean_duration_seconds_count") == before_hist_count + 1
+        assert _sample("override_mean_duration_seconds_sum") == before_hist_sum + 3600.0
+
+    def test_failed_revert_raises_and_leaves_metrics_to_the_workflow(self) -> None:
+        """On failure the workflow records the outcome via record_override_revert_failure."""
+        before_gauge = _sample("override_active_count") or 0
+        before_failure = _sample("override_auto_revert_failure_total") or 0
+
+        with (
+            patch.object(oa, "deploy_config_via_gnmi", new=AsyncMock(return_value=False)),
+            pytest.raises(RuntimeError, match="revert failed"),
+        ):
+            asyncio.run(oa.revert_override_config("leaf01", "172.20.20.2", "{}", 3600.0))
+
+        assert _sample("override_active_count") == before_gauge
+        assert _sample("override_auto_revert_failure_total") == before_failure
+
+
+@pytest.mark.unit
+class TestRecordOverrideRevertFailure:
+    """record_override_revert_failure counts the failure and clears the gauge."""
+
+    def test_records_failure_and_decrements_gauge(self) -> None:
+        before_gauge = _sample("override_active_count") or 0
+        before_failure = _sample("override_auto_revert_failure_total") or 0
+
+        asyncio.run(oa.record_override_revert_failure("leaf01", "gNMI SET failed"))
+
+        assert _sample("override_active_count") == before_gauge - 1
+        assert _sample("override_auto_revert_failure_total") == before_failure + 1
+
+
+@pytest.mark.unit
+class TestCheckReversionSafety:
+    """check_reversion_safety validates device state and sets the result gauge."""
+
+    def test_safe_state_sets_gauge_to_one(self) -> None:
+        with patch.object(oa, "check_bgp_summary", return_value=True):
+            result = asyncio.run(oa.check_reversion_safety("leaf01", "172.20.20.2"))
+
+        assert result is True
+        assert _sample("override_state_validation_result", {"device": "leaf01"}) == 1
+
+    def test_unsafe_state_sets_gauge_to_zero_without_raising(self) -> None:
+        """Unsafe is a decision input for the workflow, not an activity error."""
+        with patch.object(oa, "check_bgp_summary", return_value=False):
+            result = asyncio.run(oa.check_reversion_safety("leaf01", "172.20.20.2"))
+
+        assert result is False
+        assert _sample("override_state_validation_result", {"device": "leaf01"}) == 0
+
+
+@pytest.mark.unit
+class TestRecordOverrideExtension:
+    """record_override_extension counts window extensions."""
+
+    def test_extension_increments_counter(self) -> None:
+        before = _sample("override_extension_count_total") or 0
+
+        asyncio.run(oa.record_override_extension("leaf01-drain", 7200))
+
+        assert _sample("override_extension_count_total") == before + 1
+
+
+@pytest.mark.unit
+class TestUpdateOverrideStatus:
+    """update_override_status delegates to the Infrahub client and always closes it."""
+
+    def test_updates_status_via_client(self) -> None:
+        client = MagicMock()
+        client.update_override_status.return_value = "active"
+
+        with patch.object(oa, "InfrahubConfigClient", return_value=client):
+            asyncio.run(oa.update_override_status("leaf01-drain", "reverted"))
+
+        client.update_override_status.assert_called_once_with("leaf01-drain", "reverted")
+        client.close.assert_called_once()
+
+    def test_client_error_propagates_and_client_still_closed(self) -> None:
+        client = MagicMock()
+        client.update_override_status.side_effect = RuntimeError("Infrahub unavailable")
+
+        with (
+            patch.object(oa, "InfrahubConfigClient", return_value=client),
+            pytest.raises(RuntimeError, match="Infrahub unavailable"),
+        ):
+            asyncio.run(oa.update_override_status("leaf01-drain", "reverted"))
+
+        client.close.assert_called_once()

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -15,6 +15,7 @@ from synapse_workers import worker
 from synapse_workers.workflows.drift_remediation_workflow import DriftRemediationWorkflow
 from synapse_workers.workflows.emergency_change_workflow import EmergencyChangeWorkflow
 from synapse_workers.workflows.network_change_workflow import NetworkChangeWorkflow
+from synapse_workers.workflows.operational_override_workflow import OperationalOverrideWorkflow
 
 
 @pytest.fixture(autouse=True)
@@ -72,9 +73,10 @@ async def test_main_registers_all_workflows_and_activities() -> None:
             NetworkChangeWorkflow,
             DriftRemediationWorkflow,
             EmergencyChangeWorkflow,
+            OperationalOverrideWorkflow,
         }
 
-        # All 11 activities registered (names are stable across the codebase).
+        # All 17 activities registered (names are stable across the codebase).
         activity_names = {fn.__name__ for fn in kwargs["activities"]}
         assert activity_names == {
             "backup_running_config",
@@ -88,4 +90,10 @@ async def test_main_registers_all_workflows_and_activities() -> None:
             "validate_interfaces",
             "log_audit_event",
             "render_intended_config",
+            "apply_override_config",
+            "revert_override_config",
+            "record_override_revert_failure",
+            "check_reversion_safety",
+            "update_override_status",
+            "record_override_extension",
         }

--- a/workers/synapse_workers/activities/override_activities.py
+++ b/workers/synapse_workers/activities/override_activities.py
@@ -1,0 +1,170 @@
+"""Temporal activities for the OperationalOverrideWorkflow (Issues #48, #63).
+
+Applies and reverts time-bounded operational overrides via gNMI, keeps the
+OperationalOverride lifecycle status in Infrahub current, and emits the
+operational intent metrics. Metrics are emitted here (activities) only —
+never from workflow code, which Temporal replays and would double-count.
+
+Metric ownership per outcome:
+  - apply_override_config: override_active_count (inc on success)
+  - revert_override_config: success counter, duration histogram, gauge dec —
+    on its *success* path only; a failed revert raises without emitting so
+    Temporal can retry without double-counting
+  - record_override_revert_failure: failure counter + gauge dec, called by
+    the workflow exactly once when the revert is abandoned
+  - check_reversion_safety: override_state_validation_result per device
+  - record_override_extension: extension counter
+"""
+
+from __future__ import annotations
+
+import os
+
+from temporalio import activity
+
+from network_synapse.infrahub.client import InfrahubConfigClient
+from network_synapse.scripts.validate_state import check_bgp_summary
+from synapse_workers.activities._gnmi_io import deploy_config_via_gnmi
+from synapse_workers.metrics import (
+    override_active_count,
+    override_auto_revert_failure_total,
+    override_auto_revert_success_total,
+    override_extension_count_total,
+    override_mean_duration_seconds,
+    override_state_validation_result,
+)
+
+# TODO: Add device credential management (env vars or vault)
+# For MVP, we will use Containerlab default SR Linux credentials
+DEFAULT_USER = "admin"
+DEFAULT_PASS = "NokiaSrl1!"  # noqa: S105
+
+
+@activity.defn
+async def apply_override_config(device_hostname: str, ip_address: str, override_config_json: str) -> bool:
+    """Apply the override config to a device via gNMI SET.
+
+    On success the override becomes active on the device, so the active
+    gauge is incremented here.
+    """
+    activity.logger.info(f"Applying override config to {device_hostname} at {ip_address}")
+
+    result = await deploy_config_via_gnmi(
+        device_hostname=device_hostname,
+        ip_address=ip_address,
+        config_payload=override_config_json,
+        username=DEFAULT_USER,
+        password=DEFAULT_PASS,
+    )
+
+    if not result:
+        raise RuntimeError(f"Override apply failed for {device_hostname}")
+
+    override_active_count.inc()
+    return True
+
+
+@activity.defn
+async def revert_override_config(
+    device_hostname: str,
+    ip_address: str,
+    intended_config_json: str,
+    active_seconds: float,
+) -> bool:
+    """Converge the device back to *current* SoT intent (agreed in #161).
+
+    Args:
+        device_hostname: Device to revert.
+        ip_address: Device management IP for gNMI.
+        intended_config_json: Rendered config from the current SoT intent —
+            not the pre-override snapshot, which is audit/manual fallback only.
+        active_seconds: How long the override was active (workflow-computed,
+            deterministic), observed into the duration histogram on success.
+
+    Raises:
+        RuntimeError: If the gNMI SET fails. No metrics are emitted on
+            failure — the workflow records the final outcome via
+            record_override_revert_failure once retries are exhausted.
+    """
+    activity.logger.info(f"Reverting override on {device_hostname}: converging to current SoT intent")
+
+    result = await deploy_config_via_gnmi(
+        device_hostname=device_hostname,
+        ip_address=ip_address,
+        config_payload=intended_config_json,
+        username=DEFAULT_USER,
+        password=DEFAULT_PASS,
+    )
+
+    if not result:
+        raise RuntimeError(f"Override revert failed for {device_hostname}. Device may be stuck in exception state!")
+
+    override_active_count.dec()
+    override_auto_revert_success_total.inc()
+    override_mean_duration_seconds.observe(active_seconds)
+    return True
+
+
+@activity.defn
+async def record_override_revert_failure(device_hostname: str, reason: str) -> None:
+    """Record a permanently failed auto-revert (override enters revert_failed).
+
+    Called by the workflow exactly once when a revert is abandoned — either
+    the safety check said no or the revert deploy exhausted its retries.
+    """
+    activity.logger.error(f"Override auto-revert failed on {device_hostname}: {reason}")
+    override_active_count.dec()
+    override_auto_revert_failure_total.inc()
+
+
+@activity.defn
+async def check_reversion_safety(device_hostname: str, ip_address: str) -> bool:
+    """Validate the device is safe to converge back to intent.
+
+    Checks BGP sessions are established before reverting. Returns the
+    verdict (it does not raise on unsafe — that is a workflow decision)
+    and records it in the per-device state validation gauge.
+    """
+    activity.logger.info(f"Checking reversion safety on {device_hostname} ({ip_address})")
+    safe = bool(check_bgp_summary(ip_address))
+    override_state_validation_result.labels(device=device_hostname).set(1 if safe else 0)
+    if not safe:
+        activity.logger.warning(f"Reversion safety check failed on {device_hostname}: BGP sessions not established")
+    return safe
+
+
+@activity.defn
+async def update_override_status(override_name: str, status: str) -> None:
+    """Update the OperationalOverride lifecycle status in Infrahub.
+
+    Args:
+        override_name: Unique name of the OperationalOverride node.
+        status: Target status (pending, active, reverted, revert_failed,
+            cancelled).
+
+    Raises:
+        ValueError: If status is invalid (non-retryable).
+        RuntimeError: If the override is missing or Infrahub errors
+            (retryable by Temporal).
+    """
+    client = InfrahubConfigClient(
+        url=os.getenv("INFRAHUB_URL", "http://localhost:8000"),
+        token=os.getenv("INFRAHUB_TOKEN", ""),
+    )
+    try:
+        previous = client.update_override_status(override_name, status)
+        activity.logger.info(
+            "Override status updated: override=%s old_status=%s new_status=%s",
+            override_name,
+            previous,
+            status,
+        )
+    finally:
+        client.close()
+
+
+@activity.defn
+async def record_override_extension(override_name: str, additional_seconds: int) -> None:
+    """Record a window extension granted on an operational override."""
+    activity.logger.info(f"Override {override_name} window extended by {additional_seconds}s")
+    override_extension_count_total.inc()

--- a/workers/synapse_workers/metrics.py
+++ b/workers/synapse_workers/metrics.py
@@ -67,6 +67,48 @@ intent_decommission_age_days = Histogram(
     registry=REGISTRY,
 )
 
+# ---------------------------------------------------------------------------
+# Operational intent metrics (Issue #63) — emitted by the override activities
+# ---------------------------------------------------------------------------
+
+override_active_count = Gauge(
+    "override_active_count",
+    "Operational overrides currently active on devices",
+    registry=REGISTRY,
+)
+
+override_auto_revert_success_total = Counter(
+    "override_auto_revert_success",
+    "Overrides successfully auto-reverted to current SoT intent",
+    registry=REGISTRY,
+)
+
+override_auto_revert_failure_total = Counter(
+    "override_auto_revert_failure",
+    "Overrides whose auto-revert failed (device stuck in exception state)",
+    registry=REGISTRY,
+)
+
+override_mean_duration_seconds = Histogram(
+    "override_mean_duration_seconds",
+    "Time an override was active on the device, observed at revert",
+    buckets=(60, 300, 900, 3600, 14400, 86400, 604800, float("inf")),
+    registry=REGISTRY,
+)
+
+override_extension_count_total = Counter(
+    "override_extension_count",
+    "Window extensions granted on operational overrides",
+    registry=REGISTRY,
+)
+
+override_state_validation_result = Gauge(
+    "override_state_validation_result",
+    "Latest reversion-safety validation result per device (1 pass, 0 fail)",
+    ["device"],
+    registry=REGISTRY,
+)
+
 
 def start_metrics_server(port: int) -> None:
     """Expose the worker registry on an HTTP /metrics endpoint."""

--- a/workers/synapse_workers/worker.py
+++ b/workers/synapse_workers/worker.py
@@ -10,11 +10,20 @@ from synapse_workers.activities.config_deployment_activities import deploy_confi
 from synapse_workers.activities.device_backup_activities import backup_running_config, store_backup
 from synapse_workers.activities.drift_activities import fetch_running_config, log_audit_event, render_intended_config
 from synapse_workers.activities.infrahub_activities import fetch_device_config, update_device_status
+from synapse_workers.activities.override_activities import (
+    apply_override_config,
+    check_reversion_safety,
+    record_override_extension,
+    record_override_revert_failure,
+    revert_override_config,
+    update_override_status,
+)
 from synapse_workers.activities.validation_activities import validate_bgp, validate_interfaces
 from synapse_workers.metrics import start_metrics_server
 from synapse_workers.workflows.drift_remediation_workflow import DriftRemediationWorkflow
 from synapse_workers.workflows.emergency_change_workflow import EmergencyChangeWorkflow
 from synapse_workers.workflows.network_change_workflow import NetworkChangeWorkflow
+from synapse_workers.workflows.operational_override_workflow import OperationalOverrideWorkflow
 
 
 async def main() -> None:
@@ -33,6 +42,7 @@ async def main() -> None:
             NetworkChangeWorkflow,
             DriftRemediationWorkflow,
             EmergencyChangeWorkflow,
+            OperationalOverrideWorkflow,
         ],
         activities=[
             backup_running_config,
@@ -46,6 +56,12 @@ async def main() -> None:
             validate_interfaces,
             log_audit_event,
             render_intended_config,
+            apply_override_config,
+            revert_override_config,
+            record_override_revert_failure,
+            check_reversion_safety,
+            update_override_status,
+            record_override_extension,
         ],
     )
 

--- a/workers/synapse_workers/workflows/operational_override_workflow.py
+++ b/workers/synapse_workers/workflows/operational_override_workflow.py
@@ -1,0 +1,340 @@
+"""Workflow for time-bounded operational overrides (Issues #48, #49).
+
+Applies a sanctioned deviation from as-built intent, waits on a durable
+Temporal timer until the override window expires (or a signal arrives),
+then converges the device back to the *current* SoT intent — not the
+pre-override snapshot, which is captured for audit/manual fallback only
+(agreed in #161).
+
+Signals:
+  - terminate_early(reason): incident resolved — revert now, mark cancelled
+  - extend_window(additional_seconds, reason): incident ongoing — push
+    end_time out and track the extension count
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+from temporalio.exceptions import ApplicationError
+
+with workflow.unsafe.imports_passed_through():
+    from synapse_workers.activities.device_backup_activities import store_backup
+    from synapse_workers.activities.drift_activities import (
+        fetch_running_config,
+        log_audit_event,
+        render_intended_config,
+    )
+    from synapse_workers.activities.infrahub_activities import fetch_device_config
+    from synapse_workers.activities.override_activities import (
+        apply_override_config,
+        check_reversion_safety,
+        record_override_extension,
+        record_override_revert_failure,
+        revert_override_config,
+        update_override_status,
+    )
+
+
+# Retry policy for device communication
+device_retry_policy = RetryPolicy(
+    initial_interval=timedelta(seconds=5),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=60),
+    maximum_attempts=3,
+)
+
+
+@dataclasses.dataclass
+class OperationalOverrideInput:
+    """Input for an operational override workflow execution."""
+
+    override_name: str
+    device_hostname: str
+    ip_address: str
+    override_type: str  # admin_shutdown | maintenance_mode | traffic_drain | emergency_bypass
+    override_config_json: str
+    reason: str
+    operator: str
+    duration_seconds: int  # override window length; overrides are never open-ended
+
+
+@workflow.defn
+class OperationalOverrideWorkflow:
+    """Apply a time-bounded override, wait, auto-revert to current intent.
+
+    Steps (per Issue #48):
+      1. capture_current_state — gNMI GET, stored for audit/manual fallback
+      2. apply_override — gNMI SET with the override config
+      3. update_infrahub — mark the OperationalOverride active
+      4. wait_for_expiry_or_signal — durable timer, interruptible by signals
+      5. check_reversion_safety — BGP sessions up before touching the device
+      6. revert_to_original — converge to *current* SoT intent
+      7. mark_completed — status reverted (expiry) or cancelled (early stop)
+    """
+
+    def __init__(self) -> None:
+        self._terminated = False
+        self._terminate_reason = ""
+        self._pending_extensions: list[tuple[int, str]] = []
+
+    @workflow.signal
+    def terminate_early(self, reason: str) -> None:
+        """Incident resolved — revert the override before the window expires."""
+        workflow.logger.info(f"Early termination requested: {reason}")
+        self._terminated = True
+        self._terminate_reason = reason
+
+    @workflow.signal
+    def extend_window(self, additional_seconds: int, reason: str) -> None:
+        """Incident ongoing — extend the override window."""
+        if additional_seconds <= 0:
+            workflow.logger.warning(f"Ignoring non-positive window extension: {additional_seconds}s ({reason})")
+            return
+        workflow.logger.info(f"Window extension requested: +{additional_seconds}s ({reason})")
+        self._pending_extensions.append((additional_seconds, reason))
+
+    @workflow.run
+    async def run(self, override_input: OperationalOverrideInput) -> str:
+        """Execute the override lifecycle.
+
+        Returns:
+            "OVERRIDE_REVERTED" if the window expired and auto-revert ran,
+            "OVERRIDE_CANCELLED" if terminated early on request.
+
+        Raises:
+            ApplicationError: If the apply fails, the reversion safety check
+                says no, or the revert fails (override enters revert_failed).
+        """
+        name = override_input.override_name
+        device = override_input.device_hostname
+        ip = override_input.ip_address
+
+        if override_input.duration_seconds <= 0:
+            raise ApplicationError(
+                "duration_seconds must be > 0 — overrides are always time-bounded", non_retryable=True
+            )
+
+        workflow.logger.info(
+            f"Override {name} ({override_input.override_type}) initiated for {device} "
+            f"by {override_input.operator}: {override_input.reason}"
+        )
+
+        await workflow.execute_activity(
+            log_audit_event,
+            args=[
+                "OVERRIDE_INITIATED",
+                device,
+                f"override={name} type={override_input.override_type} "
+                f"operator={override_input.operator} reason={override_input.reason}",
+            ],
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+
+        # 1. Capture current state (OverrideAction.original_state — audit/manual fallback)
+        original_state = await workflow.execute_activity(
+            fetch_running_config,
+            args=[device, ip],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=device_retry_policy,
+        )
+        await workflow.execute_activity(
+            store_backup,
+            args=[device, original_state],
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=device_retry_policy,
+        )
+
+        # 2. Apply the override config
+        try:
+            await workflow.execute_activity(
+                apply_override_config,
+                args=[device, ip, override_input.override_config_json],
+                start_to_close_timeout=timedelta(seconds=60),
+                retry_policy=device_retry_policy,
+            )
+        except Exception as e:
+            workflow.logger.error(f"Override apply failed on {device}: {e!s}")
+            try:
+                await workflow.execute_activity(
+                    log_audit_event,
+                    args=["OVERRIDE_APPLY_FAILED", device, f"override={name} error={e!s}"],
+                    start_to_close_timeout=timedelta(seconds=10),
+                )
+            except Exception as audit_exc:
+                workflow.logger.error(f"Failed to audit OVERRIDE_APPLY_FAILED for {device}: {audit_exc!s}")
+            raise ApplicationError(f"Override apply failed for {device}: {e!s}", non_retryable=True) from e
+
+        # 3. Mark the override active in Infrahub
+        await workflow.execute_activity(
+            update_override_status,
+            args=[name, "active"],
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=device_retry_policy,
+        )
+
+        applied_at = workflow.now()
+        end_time = applied_at + timedelta(seconds=override_input.duration_seconds)
+
+        await workflow.execute_activity(
+            log_audit_event,
+            args=[
+                "OVERRIDE_APPLIED",
+                device,
+                f"override={name} window={override_input.duration_seconds}s ends={end_time.isoformat()}",
+            ],
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+
+        # 4. Wait for window expiry, early termination, or extension
+        await self._wait_for_expiry_or_signal(name, device, end_time)
+
+        early = self._terminated
+        if early:
+            await workflow.execute_activity(
+                log_audit_event,
+                args=["OVERRIDE_TERMINATED_EARLY", device, f"override={name} reason={self._terminate_reason}"],
+                start_to_close_timeout=timedelta(seconds=10),
+            )
+
+        # 5. Reversion safety check — never converge a device that isn't healthy
+        safe = await workflow.execute_activity(
+            check_reversion_safety,
+            args=[device, ip],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=device_retry_policy,
+        )
+        if not safe:
+            workflow.logger.error(f"Reversion safety check failed on {device} — override {name} stuck")
+            await self._mark_revert_failed(name, device, "reversion safety check failed")
+            await workflow.execute_activity(
+                log_audit_event,
+                args=["OVERRIDE_REVERT_UNSAFE", device, f"override={name} safety check failed"],
+                start_to_close_timeout=timedelta(seconds=10),
+            )
+            raise ApplicationError(
+                f"Override revert aborted for {device}: reversion safety check failed", non_retryable=True
+            )
+
+        # 6. Revert — converge to *current* SoT intent, not the snapshot (#161)
+        device_data = await workflow.execute_activity(
+            fetch_device_config,
+            args=[device],
+            start_to_close_timeout=timedelta(seconds=30),
+        )
+        intended_config_json = await workflow.execute_activity(
+            render_intended_config,
+            args=[device_data["interfaces"]],
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+
+        active_seconds = (workflow.now() - applied_at).total_seconds()
+        try:
+            await workflow.execute_activity(
+                revert_override_config,
+                args=[device, ip, intended_config_json, active_seconds],
+                start_to_close_timeout=timedelta(seconds=60),
+                retry_policy=device_retry_policy,
+            )
+        except Exception as e:
+            workflow.logger.error(f"Override revert failed on {device}: {e!s}")
+            await self._mark_revert_failed(name, device, str(e))
+            try:
+                await workflow.execute_activity(
+                    log_audit_event,
+                    args=["OVERRIDE_REVERT_FAILED", device, f"override={name} error={e!s}"],
+                    start_to_close_timeout=timedelta(seconds=10),
+                )
+            except Exception as audit_exc:
+                workflow.logger.error(f"Failed to audit OVERRIDE_REVERT_FAILED for {device}: {audit_exc!s}")
+            raise ApplicationError(f"Override revert failed for {device}: {e!s}", non_retryable=True) from e
+
+        # 7. Mark completed. The device is already converged, so a status or
+        # audit write failure is logged but never fails the workflow.
+        final_status = "cancelled" if early else "reverted"
+        try:
+            await workflow.execute_activity(
+                update_override_status,
+                args=[name, final_status],
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=device_retry_policy,
+            )
+        except Exception as status_exc:
+            workflow.logger.error(f"Failed to mark override {name} {final_status} after revert: {status_exc!s}")
+        try:
+            await workflow.execute_activity(
+                log_audit_event,
+                args=[
+                    "OVERRIDE_CANCELLED" if early else "OVERRIDE_REVERTED",
+                    device,
+                    f"override={name} active_seconds={active_seconds:.0f}",
+                ],
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=device_retry_policy,
+            )
+        except Exception as audit_exc:
+            workflow.logger.error(f"Failed to audit override completion for {device}: {audit_exc!s}")
+
+        workflow.logger.info(f"Override {name} {'cancelled early' if early else 'reverted'} on {device}")
+        return "OVERRIDE_CANCELLED" if early else "OVERRIDE_REVERTED"
+
+    async def _wait_for_expiry_or_signal(self, name: str, device: str, end_time: datetime) -> None:
+        """Durable wait until end_time, processing extension/termination signals."""
+        while not self._terminated:
+            while self._pending_extensions:
+                additional_seconds, extension_reason = self._pending_extensions.pop(0)
+                end_time += timedelta(seconds=additional_seconds)
+                await workflow.execute_activity(
+                    record_override_extension,
+                    args=[name, additional_seconds],
+                    start_to_close_timeout=timedelta(seconds=10),
+                )
+                await workflow.execute_activity(
+                    log_audit_event,
+                    args=[
+                        "OVERRIDE_EXTENDED",
+                        device,
+                        f"override={name} extended_by={additional_seconds}s "
+                        f"ends={end_time.isoformat()} reason={extension_reason}",
+                    ],
+                    start_to_close_timeout=timedelta(seconds=10),
+                )
+
+            remaining = (end_time - workflow.now()).total_seconds()
+            if remaining <= 0:
+                workflow.logger.info(f"Override {name} window expired on {device}")
+                break
+
+            try:
+                await workflow.wait_condition(
+                    lambda: self._terminated or bool(self._pending_extensions),
+                    timeout=timedelta(seconds=remaining),
+                )
+            except TimeoutError:
+                # Timer fired — loop re-checks end_time in case an extension
+                # landed in the same instant as the timeout.
+                continue
+
+    async def _mark_revert_failed(self, name: str, device: str, reason: str) -> None:
+        """Record the failed revert (metrics) and set status revert_failed.
+
+        Best-effort: the workflow is about to raise the real error, so
+        bookkeeping failures are logged rather than masking it.
+        """
+        try:
+            await workflow.execute_activity(
+                record_override_revert_failure,
+                args=[device, reason],
+                start_to_close_timeout=timedelta(seconds=10),
+            )
+            await workflow.execute_activity(
+                update_override_status,
+                args=[name, "revert_failed"],
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=device_retry_policy,
+            )
+        except Exception as cleanup_exc:
+            workflow.logger.error(f"Failed to record revert failure for {device}: {cleanup_exc!s}")


### PR DESCRIPTION
## Summary

Implements the operational intent runtime on top of the schema landed for #161: a Temporal workflow that applies a time-bounded override, waits out its window on a durable timer, and auto-reverts the device to the **current** source-of-truth intent — plus the signals and metrics that make it operable.

Closes #48
Closes #49
Closes #63

## What's included

**OperationalOverrideWorkflow (#48)** — capture current state → apply override via gNMI → mark `active` in Infrahub → durable-timer wait → reversion-safety check → converge to current SoT intent (not the pre-override snapshot, per the #161 decision) → mark `reverted`. Apply failures abort before the override goes active; failed or unsafe reverts mark it `revert_failed`.

**Signals (#49)** — `terminate_early(reason)` reverts early and marks `cancelled`; `extend_window(seconds, reason)` pushes out `end_time` and tracks the extension count.

**Operational intent metrics (#63)** — six metrics on the worker `/metrics` endpoint, emitted from activities only (never from replayed workflow code): `override_active_count`, `override_auto_revert_success_total`, `override_auto_revert_failure_total`, `override_mean_duration_seconds`, `override_extension_count_total`, `override_state_validation_result`.

**Supporting** — `InfrahubConfigClient.update_override_status()`, new activities + workflow registered on the worker, conftest spies, changelog fragments.

## Testing

- `407` unit tests pass, including 7 new Temporal-backed workflow tests (`test_operational_override_workflow.py`) covering expiry, early termination, window extension, apply failure, revert failure, unsafe reversion, and input validation.
- New-code coverage: override activities 100%, workflow 89%, client method covered.
- `uv run invoke lint` and `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)