### PR TITLE
fix: propagate gNMI transport errors from deploy_config

### DIFF
--- a/backend/network_synapse/scripts/deploy_configs.py
+++ b/backend/network_synapse/scripts/deploy_configs.py
@@ -15,32 +15,36 @@ def deploy_config(
     password: str = "NokiaSrl1!",  # noqa: S107
     port: int = 57400,
 ) -> bool:
-    """Deploy a JSON configuration to a Nokia SR Linux device via gNMI."""
+    """Deploy a JSON configuration to a Nokia SR Linux device via gNMI.
+
+    Transport-level failures (gNMI/gRPC/connection errors) are NOT swallowed:
+    they propagate so that :func:`_gnmi_io.deploy_config_via_gnmi` can classify
+    and rewrap them for Temporal, and genuine programming bugs surface with a
+    real traceback instead of being masked as a generic failure. A ``False``
+    return now means exactly one thing: the device was reached but did not
+    acknowledge the SET (or the payload was not valid JSON, so nothing was
+    pushed).
+    """
     logger.info(f"Deploying configuration to {hostname} ({ip_address}:{port})")
 
     try:
-        try:
-            config_dict = json.loads(config_payload)
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse config payload as JSON for {hostname}: {e!s}")
-            return False
+        config_dict = json.loads(config_payload)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse config payload as JSON for {hostname}: {e!s}")
+        return False
 
-        host = (ip_address, port)
+    host = (ip_address, port)
 
-        with gNMIclient(target=host, username=username, password=password, insecure=True) as gc:
-            logger.debug(f"Successfully connected to gNMI on {hostname}")
-            update_req = [("/", config_dict)]
-            result = gc.set(update=update_req)
-            logger.info(f"gNMI SET response for {hostname}: {result}")
+    with gNMIclient(target=host, username=username, password=password, insecure=True) as gc:
+        logger.debug(f"Successfully connected to gNMI on {hostname}")
+        update_req = [("/", config_dict)]
+        result = gc.set(update=update_req)
+        logger.info(f"gNMI SET response for {hostname}: {result}")
 
-            if result.get("response"):
-                logger.info(f"Configuration successfully deployed to {hostname}")
-                return True
-            logger.error(f"Unexpected gNMI response from {hostname}: {result}")
-            return False
-
-    except Exception as e:
-        logger.error(f"Failed to deploy configuration to {hostname}: {e!s}")
+        if result.get("response"):
+            logger.info(f"Configuration successfully deployed to {hostname}")
+            return True
+        logger.error(f"Unexpected gNMI response from {hostname}: {result}")
         return False
 
 

--- a/changelog/167.fixed.md
+++ b/changelog/167.fixed.md
@@ -1,0 +1,1 @@
+Stopped `deploy_config` from swallowing gNMI transport errors into a `False` return, so `_gnmi_io` can classify and rewrap them and genuine bugs surface with a real traceback.

--- a/tests/unit/test_deploy_configs.py
+++ b/tests/unit/test_deploy_configs.py
@@ -1,0 +1,67 @@
+"""Unit tests for `deploy_configs.deploy_config` (Issue #167).
+
+The script-level SET helper was previously exercised only indirectly via the
+mocked `push_via_gnmi` in `test_gnmi_io.py`, so its error handling was untested.
+These tests pin the contract the `_gnmi_io` layer relies on:
+
+  - A successful SET returns ``True``.
+  - A response without a ``response`` key returns ``False`` (device reached but
+    did not acknowledge the SET).
+  - Invalid JSON returns ``False`` (bad payload, nothing pushed).
+  - Transport errors PROPAGATE — they must not be swallowed into ``False``,
+    otherwise `_gnmi_io.deploy_config_via_gnmi` can never classify and rewrap
+    them.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pygnmi.client import gNMIException
+
+from network_synapse.scripts import deploy_configs
+
+
+def _fake_client(set_result: dict) -> MagicMock:
+    """Build a gNMIclient factory whose context manager returns a client
+    whose ``set`` yields ``set_result``."""
+    gc = MagicMock()
+    gc.set.return_value = set_result
+    factory = MagicMock()
+    factory.return_value.__enter__.return_value = gc
+    factory.return_value.__exit__.return_value = False
+    return factory
+
+
+@pytest.mark.unit
+class TestDeployConfig:
+    def test_successful_set_returns_true(self) -> None:
+        factory = _fake_client({"response": [{"path": "/", "op": "UPDATE"}]})
+        with patch.object(deploy_configs, "gNMIclient", factory):
+            assert deploy_configs.deploy_config("spine01", "172.20.20.3", '{"a": 1}') is True
+
+    def test_missing_response_returns_false(self) -> None:
+        factory = _fake_client({"unexpected": True})
+        with patch.object(deploy_configs, "gNMIclient", factory):
+            assert deploy_configs.deploy_config("spine01", "172.20.20.3", '{"a": 1}') is False
+
+    def test_invalid_json_returns_false(self) -> None:
+        # Malformed payload: must never reach the gNMI client.
+        factory = _fake_client({"response": [{}]})
+        with patch.object(deploy_configs, "gNMIclient", factory):
+            assert deploy_configs.deploy_config("spine01", "172.20.20.3", "{not-json") is False
+        factory.assert_not_called()
+
+    def test_transport_error_propagates(self) -> None:
+        """A gNMI transport error must bubble up, not be swallowed into False.
+
+        `_gnmi_io.deploy_config_via_gnmi` catches this specific exception type to
+        rewrap it as RuntimeError; if `deploy_config` swallows it, that
+        classification is dead code.
+        """
+        factory = MagicMock()
+        factory.return_value.__enter__.side_effect = gNMIException("UNAVAILABLE", None)
+        factory.return_value.__exit__.return_value = False
+        with patch.object(deploy_configs, "gNMIclient", factory), pytest.raises(gNMIException):
+            deploy_configs.deploy_config("spine01", "172.20.20.3", '{"a": 1}')


### PR DESCRIPTION
## Summary

`deploy_configs.deploy_config` wrapped its whole body in `except Exception: return False`. Its only caller, `_gnmi_io.deploy_config_via_gnmi` (imported as `push_via_gnmi`), catches a **specific** set of transport errors (`gNMIException`, `grpc.RpcError`, `ConnectionError`, `OSError`, `TimeoutError`) to rewrap them as `RuntimeError` for Temporal. Because `deploy_config` swallowed everything first, that classification was **dead code**, and genuine bugs (e.g. `KeyError`) were masked as a generic "deployment failed" and retried 3× with no traceback.

This lets exceptions propagate. `False` now means exactly one thing: the device was reached but did not acknowledge the SET (or the payload was not valid JSON, so nothing was pushed).

## Changes

- `deploy_configs.py`: drop the catch-all `except Exception`; keep `False` only for the "no `response`" and bad-JSON cases.
- **New** `tests/unit/test_deploy_configs.py` — the script fn was previously only tested indirectly via a mocked `push_via_gnmi`. Covers success → `True`, missing `response` → `False`, invalid JSON → `False` (client never called), and transport error → **propagates**.

## Testing

- New test file written first (red on the transport-propagation case), then fix (green).
- Full unit suite: 411 passed. `invoke lint`, `format`, `scan` clean. MyPy neutral (the 13 pre-existing errors are unchanged and `continue-on-error` in CI).

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)