### PR TITLE
fix: pin static lab mgmt IPs — no clashes with other labs on the shared clab network

### DIFF
--- a/backend/network_synapse/data/seed_data.yml
+++ b/backend/network_synapse/data/seed_data.yml
@@ -56,7 +56,7 @@ devices:
     role: spine
     status: active
     device_type: "7220 IXR-D3"
-    management_ip: "172.20.20.3/24"
+    management_ip: "172.20.20.10/24"
     lab_node_name: "clab-spine-leaf-lab-spine01"
     asn: 65000
     description: "Spine switch - Nokia 7220 IXR-D3"
@@ -65,7 +65,7 @@ devices:
     role: leaf
     status: active
     device_type: "7220 IXR-D2"
-    management_ip: "172.20.20.2/24"
+    management_ip: "172.20.20.11/24"
     lab_node_name: "clab-spine-leaf-lab-leaf01"
     asn: 65001
     description: "Leaf switch 01 - Nokia 7220 IXR-D2"
@@ -74,7 +74,7 @@ devices:
     role: leaf
     status: active
     device_type: "7220 IXR-D2"
-    management_ip: "172.20.20.4/24"
+    management_ip: "172.20.20.12/24"
     lab_node_name: "clab-spine-leaf-lab-leaf02"
     asn: 65002
     description: "Leaf switch 02 - Nokia 7220 IXR-D2"

--- a/backend/network_synapse/scripts/configure_syslog.py
+++ b/backend/network_synapse/scripts/configure_syslog.py
@@ -33,11 +33,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_COLLECTOR_HOST = "172.20.20.1"
 DEFAULT_SYSLOG_PORT = 5514
 
-# Fabric nodes by containerlab DNS name (mgmt IPs are DHCP-assigned).
+# Fabric nodes by pinned mgmt-ipv4 (topology.clab.yml, Issue #178).
+# The script runs on the macOS host, where containerlab DNS names do not
+# resolve — only containers on the docker network can use them.
 FABRIC_DEVICES = {
-    "spine01": "clab-spine-leaf-lab-spine01",
-    "leaf01": "clab-spine-leaf-lab-leaf01",
-    "leaf02": "clab-spine-leaf-lab-leaf02",
+    "spine01": "172.20.20.10",
+    "leaf01": "172.20.20.11",
+    "leaf02": "172.20.20.12",
 }
 
 

--- a/changelog/178.fixed.md
+++ b/changelog/178.fixed.md
@@ -1,0 +1,1 @@
+Pinned static management IPs (172.20.20.10–.15) for all spine-leaf-lab nodes and aligned the Infrahub seed data, docs, and e2e test defaults. The shared `clab` network hands out dynamic addresses from the bottom of the subnet, so the previously DHCP-assigned SoT addresses could point at another lab's SR Linux nodes — a workflow would have pushed config to a foreign device.

--- a/containerlab/topology.clab.yml
+++ b/containerlab/topology.clab.yml
@@ -1,9 +1,17 @@
 # Spine-leaf topology definition for Containerlab — Nokia SR Linux
 # Deployed on: local OrbStack (macOS Apple Silicon)
-# Management network: 172.20.20.0/24 (DHCP assigned by clab)
+# Management network: 172.20.20.0/24, static mgmt IPs (Issue #178).
+# The `clab` network is shared with other containerlab deployments on this
+# host, which draw dynamic addresses from the bottom of the subnet — every
+# node here is pinned at .10+ so the SoT seed data (seed_data.yml) always
+# points at *these* nodes, never at a foreign lab's.
 # Deploy: sudo containerlab deploy --topo topology.clab.yml
 # Destroy: sudo containerlab destroy --topo topology.clab.yml
 name: spine-leaf-lab
+
+mgmt:
+  network: clab
+  ipv4-subnet: 172.20.20.0/24
 
 topology:
   kinds:
@@ -14,17 +22,21 @@ topology:
     spine01:
       kind: nokia_srlinux
       type: ixr-d3
+      mgmt-ipv4: 172.20.20.10
     leaf01:
       kind: nokia_srlinux
       type: ixr-d2
+      mgmt-ipv4: 172.20.20.11
     leaf02:
       kind: nokia_srlinux
       type: ixr-d2
+      mgmt-ipv4: 172.20.20.12
 
     # --- Firewall (Alpine + iptables) on Leaf 02 ---
     firewall:
       kind: linux
       image: wbitt/network-multitool@sha256:00bf63b9e033362a4adf138c4b14d92bc6ce52446358fed4da14c2e16e8a64aa
+      mgmt-ipv4: 172.20.20.13
       sysctls:
         net.ipv4.ip_forward: 1
       exec:
@@ -34,10 +46,12 @@ topology:
     pc1:
       kind: linux
       image: wbitt/network-multitool:alpine-extra
+      mgmt-ipv4: 172.20.20.14
 
     pc2:
       kind: linux
       image: wbitt/network-multitool:alpine-extra
+      mgmt-ipv4: 172.20.20.15
 
   links:
     # Spine-Leaf Fabric Links

--- a/dev/skills/containerlab/SKILL.md
+++ b/dev/skills/containerlab/SKILL.md
@@ -81,7 +81,8 @@ docker exec -it clab-spine-leaf-lab-firewall /bin/bash
 docker exec -it clab-spine-leaf-lab-pc1 /bin/sh
 docker exec -it clab-spine-leaf-lab-pc2 /bin/sh
 
-# DNS names (from macOS)
+# DNS names (resolve from containers on the clab docker network ONLY —
+# NOT from macOS; host-side scripts must use the pinned mgmt IPs)
 clab-spine-leaf-lab-spine01
 clab-spine-leaf-lab-leaf01
 clab-spine-leaf-lab-leaf02
@@ -93,7 +94,7 @@ clab-spine-leaf-lab-pc2
 ## Management Network
 
 - Network: `172.20.20.0/24`
-- DHCP assigned by Containerlab
+- Static mgmt IPs: spine01=.10, leaf01=.11, leaf02=.12, firewall=.13, pc1=.14, pc2=.15 (the `clab` network is shared with other labs; Issue #178)
 - Access from macOS host via OrbStack network bridge
 - gNMI ports: spine01=57400, leaf01=57401, leaf02=57402
 

--- a/dev/skills/srlinux-gnmi/SKILL.md
+++ b/dev/skills/srlinux-gnmi/SKILL.md
@@ -93,7 +93,7 @@ The lab runs 3 Nokia SR Linux nodes via Containerlab:
 | leaf01 | Leaf | IXR-D2 | 65001 | 57401 |
 | leaf02 | Leaf | IXR-D2 | 65002 | 57402 |
 
-Management network: `172.20.20.0/24` (DHCP by Containerlab).
+Management network: `172.20.20.0/24`, static pins: spine01=.10, leaf01=.11, leaf02=.12 (Issue #178 — the network is shared with other labs).
 
 ## Common Mistakes
 

--- a/development/alloy/config.alloy
+++ b/development/alloy/config.alloy
@@ -1,10 +1,13 @@
 // Grafana Alloy — SR Linux syslog ingestion (Issue #169)
 //
-// SR Linux nodes send RFC3164 syslog over UDP to the clab bridge gateway
+// SR Linux nodes send syslog over UDP to the clab bridge gateway
 // (172.20.20.1 = the OrbStack host), which forwards to the listener
-// published on host port 5514 (see docker-compose-deps.yml). Messages are
-// normalized (hostname → device, severity/facility/app labels) and pushed
-// to Loki, where they are queryable from Grafana.
+// published on host port 5514 (see docker-compose-deps.yml). SR Linux
+// emits RSYSLOG_SyslogProtocol23Format — RFC5424-style framing (verified
+// from the rsyslog config it generates on-device); an rfc3164 listener
+// drops every message with a parse error. Messages are normalized
+// (hostname → device, severity/facility/app labels) and pushed to Loki,
+// where they are queryable from Grafana.
 //
 // Device-side config is pushed by:
 //   uv run python -m network_synapse.scripts.configure_syslog
@@ -13,7 +16,7 @@ loki.source.syslog "srlinux" {
   listener {
     address       = "0.0.0.0:5514"
     protocol      = "udp"
-    syslog_format = "rfc3164"
+    syslog_format = "rfc5424"
     labels        = {
       job = "srlinux-syslog",
     }

--- a/docs/collector.md
+++ b/docs/collector.md
@@ -25,7 +25,7 @@ Three ingestion paths, all started by `uv run invoke dev.deps`:
 |------|-----------|-----------|------|-----------|
 | Streaming telemetry | gnmic | gNMI subscribe (TLS) | Prometheus | PromQL / Grafana |
 | Snapshot polling | Suzieq poller | SSH | Parquet | Suzieq REST API |
-| Logs | Grafana Alloy | Syslog UDP (RFC3164) | Loki | LogQL / Grafana |
+| Logs | Grafana Alloy | Syslog UDP (RFC5424) | Loki | LogQL / Grafana |
 
 The collector containers join the external `clab` docker network to reach
 the SR Linux management interfaces. `invoke dev.deps` pre-creates that
@@ -90,7 +90,8 @@ dev-only value; the API is bound to localhost.
 ## Syslog ingestion (Alloy → Loki)
 
 SR Linux forwards syslog to the collector; Grafana Alloy listens on host
-port `5514/udp` (RFC3164), normalizes the header fields onto the stack's
+port `5514/udp` (RFC5424 — SR Linux emits RSYSLOG_SyslogProtocol23Format,
+verified on-device), normalizes the header fields onto the stack's
 label names (`device`, `severity`, `facility`, `app`), and pushes to Loki.
 Loki is provisioned as a Grafana datasource.
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -23,12 +23,12 @@ Spine-leaf topology with 1 spine and 2 leaf switches, all Nokia SR Linux.
 
 | Device | Role | Type | Management IP | Container Name |
 |--------|------|------|---------------|----------------|
-| spine01 | spine | 7220 IXR-D3 | 172.20.20.3 | clab-spine-leaf-lab-spine01 |
-| leaf01 | leaf | 7220 IXR-D2 | 172.20.20.2 | clab-spine-leaf-lab-leaf01 |
-| leaf02 | leaf | 7220 IXR-D2 | 172.20.20.4 | clab-spine-leaf-lab-leaf02 |
-| firewall| firewall| VyOS 1.4 | DHCP | clab-spine-leaf-lab-firewall |
-| pc1     | client | Linux (Alpine) | DHCP | clab-spine-leaf-lab-pc1 |
-| pc2     | client | Linux (Alpine) | DHCP | clab-spine-leaf-lab-pc2 |
+| spine01 | spine | 7220 IXR-D3 | 172.20.20.10 | clab-spine-leaf-lab-spine01 |
+| leaf01 | leaf | 7220 IXR-D2 | 172.20.20.11 | clab-spine-leaf-lab-leaf01 |
+| leaf02 | leaf | 7220 IXR-D2 | 172.20.20.12 | clab-spine-leaf-lab-leaf02 |
+| firewall| firewall| VyOS 1.4 | 172.20.20.13 | clab-spine-leaf-lab-firewall |
+| pc1     | client | Linux (Alpine) | 172.20.20.14 | clab-spine-leaf-lab-pc1 |
+| pc2     | client | Linux (Alpine) | 172.20.20.15 | clab-spine-leaf-lab-pc2 |
 
 ### Credentials
 
@@ -43,15 +43,15 @@ No tunnels or proxy setup required.
 
 ```bash
 # SSH into a device (directly from macOS terminal)
-ssh admin@172.20.20.3          # spine01
-ssh admin@172.20.20.2          # leaf01
-ssh admin@172.20.20.4          # leaf02
+ssh admin@172.20.20.10          # spine01
+ssh admin@172.20.20.11          # leaf01
+ssh admin@172.20.20.12          # leaf02
 ```
 
 ### JSON-RPC (HTTPS, port 443)
 
 ```bash
-curl -sk https://172.20.20.3/jsonrpc -u admin:NokiaSrl1! \
+curl -sk https://172.20.20.10/jsonrpc -u admin:NokiaSrl1! \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -69,7 +69,7 @@ curl -sk https://172.20.20.3/jsonrpc -u admin:NokiaSrl1! \
 
 ```bash
 # Using pygnmi or similar
-# Target: 172.20.20.3:57400 (spine01)
+# Target: 172.20.20.10:57400 (spine01)
 # TLS: insecure (self-signed cert)
 ```
 
@@ -405,7 +405,7 @@ sudo containerlab inspect -t containerlab/topology.clab.yml
 docker network ls | grep clab
 
 # Ping from macOS (OrbStack makes this work directly)
-ping -c 2 172.20.20.3
+ping -c 2 172.20.20.10
 ```
 
 ### Port conflict

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -29,7 +29,7 @@
    leaf03:
      kind: nokia_srlinux
      image: ghcr.io/nokia/srlinux:latest
-     mgmt-ipv4: 172.20.20.13
+     mgmt-ipv4: 172.20.20.16  # .10-.15 are taken by existing nodes
    ```
 
 3. **Add to Suzieq inventory:**
@@ -207,9 +207,9 @@ docker compose -f development/docker-compose-deps.yml up -d temporal
 2. **Alternatively, SSH directly (OrbStack makes 172.20.20.x reachable):**
 
    ```bash
-   ssh admin@172.20.20.3  # spine01
-   ssh admin@172.20.20.2  # leaf01
-   ssh admin@172.20.20.4  # leaf02
+   ssh admin@172.20.20.10  # spine01
+   ssh admin@172.20.20.11  # leaf01
+   ssh admin@172.20.20.12  # leaf02
    # Password: NokiaSrl1!
    ```
 

--- a/docs/seed-data.md
+++ b/docs/seed-data.md
@@ -73,9 +73,9 @@ See [resource-manager.md](resource-manager.md) for details on pool allocation.
 
 | Device | Role | Type | Management IP | Containerlab Name | ASN |
 |--------|------|------|---------------|-------------------|-----|
-| spine01 | spine | 7220 IXR-D3 | 172.20.20.3/24 | clab-spine-leaf-lab-spine01 | 65000 |
-| leaf01 | leaf | 7220 IXR-D2 | 172.20.20.2/24 | clab-spine-leaf-lab-leaf01 | 65001 |
-| leaf02 | leaf | 7220 IXR-D2 | 172.20.20.4/24 | clab-spine-leaf-lab-leaf02 | 65002 |
+| spine01 | spine | 7220 IXR-D3 | 172.20.20.10/24 | clab-spine-leaf-lab-spine01 | 65000 |
+| leaf01 | leaf | 7220 IXR-D2 | 172.20.20.11/24 | clab-spine-leaf-lab-leaf01 | 65001 |
+| leaf02 | leaf | 7220 IXR-D2 | 172.20.20.12/24 | clab-spine-leaf-lab-leaf02 | 65002 |
 
 > **Note:** The Containerlab topology explicitly includes additional nodes (`firewall` (VyOS), `pc1`, `pc2`) that are excluded from the Infrahub Source of Truth as they are purely logical end-hosts for verifying data plane connectivity.
 

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -19,11 +19,16 @@ from .shared import PROJECT_ROOT, execute_command
 _CLAB_IMAGE = "ghcr.io/srl-labs/clab:latest"
 
 
-def _clab_docker_cmd(quoted_root: str, clab_args: str, *, docker_flags: str = "--rm -it --privileged") -> str:
+def _clab_docker_cmd(
+    quoted_root: str, clab_args: str, *, docker_flags: str = "--rm -it --privileged --pid host"
+) -> str:
     """Build a Docker command for running Containerlab inside a container.
 
     Centralises the common volume mounts required for Docker-outside-of-Docker
-    Containerlab execution.
+    Containerlab execution. ``--pid host`` is required on OrbStack: without it
+    containerlab cannot resolve the started nodes' network-namespace paths
+    ("namespace path not available") and every deploy fails after creating
+    the containers.
     """
     return (
         f"docker run {docker_flags} --network host "
@@ -118,7 +123,7 @@ def lab_graph(ctx: Context) -> None:
         _clab_docker_cmd(
             quoted_root,
             f"containerlab graph --topo {topo}",
-            docker_flags="-d --rm --name clab-graph --privileged",
+            docker_flags="-d --rm --name clab-graph --privileged --pid host",
         ),
     )
     print("Serving topology graph on http://localhost:50080")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,14 @@ from network_synapse.infrahub.models import (
     InterfaceData,
 )
 
-# ─── Containerlab mgmt IPs (DHCP-assigned, may change on redeploy) ───
-# Current assignment (OrbStack / Containerlab):
-#   leaf01:  172.20.20.2
-#   spine01: 172.20.20.3
-#   leaf02:  172.20.20.4
+# ─── Containerlab mgmt IPs (statically pinned, Issue #178) ───
+# topology.clab.yml pins:
+#   spine01: 172.20.20.10
+#   leaf01:  172.20.20.11
+#   leaf02:  172.20.20.12
 # For integration tests, use the clab_topology fixture below.
-# For unit tests, fixtures use stable placeholder IPs (mocked, not real).
+# For unit tests, fixtures use stable placeholder IPs (mocked, not real —
+# the historical .2/.3/.4 values are arbitrary and never dialled).
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -64,7 +64,7 @@ def test_config_deploy_and_validate():
     )
     from network_synapse.scripts.validate_state import check_bgp_summary
 
-    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.2")
+    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.11")
     hostname = os.getenv("TEST_DEVICE_HOSTNAME", "spine01")
 
     # 1. Verify connectivity
@@ -127,7 +127,7 @@ def test_rollback_restores_config():
         validate_gnmi_connection,
     )
 
-    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.2")
+    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.11")
     hostname = os.getenv("TEST_DEVICE_HOSTNAME", "spine01")
 
     if not validate_gnmi_connection(device_ip):

--- a/tests/e2e/test_rollback_restores_device.py
+++ b/tests/e2e/test_rollback_restores_device.py
@@ -10,7 +10,7 @@ Runs against the containerlab-default gNMI server, which is TLS-only — the
 test defaults ``GNMI_TLS_MODE`` to ``skip-verify`` on the standard port
 (Issue #166 made the transport configurable). Override the target via::
 
-    TEST_GNMI_IP=172.20.20.2 TEST_GNMI_PORT=57400 pytest tests/e2e -m e2e -k rollback
+    TEST_GNMI_IP=172.20.20.11 TEST_GNMI_PORT=57400 pytest tests/e2e -m e2e -k rollback
 
 The test restores the device from its own baseline in a ``finally`` block, so
 a failing assertion does not leave the lab node dirty.
@@ -26,7 +26,7 @@ import socket
 import pytest
 
 DEVICE_HOSTNAME = os.getenv("TEST_DEVICE_HOSTNAME", "leaf01")
-GNMI_IP = os.getenv("TEST_GNMI_IP", "172.20.20.2")
+GNMI_IP = os.getenv("TEST_GNMI_IP", "172.20.20.11")
 GNMI_PORT = int(os.getenv("TEST_GNMI_PORT", "57400"))
 GNMI_USER = os.getenv("TEST_GNMI_USER", "admin")
 GNMI_PASS = os.getenv("TEST_GNMI_PASS", "NokiaSrl1!")

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -73,7 +73,7 @@ def test_containerlab_gnmi_connectivity():
     """Verify gNMI connectivity to a Containerlab SR Linux node."""
     from network_synapse.scripts.deploy_configs import validate_gnmi_connection
 
-    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.2")
+    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.11")
     assert validate_gnmi_connection(device_ip)
 
 
@@ -82,7 +82,7 @@ def test_containerlab_bgp_state():
     """Verify BGP sessions are established on a Containerlab device."""
     from network_synapse.scripts.validate_state import check_bgp_summary
 
-    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.2")
+    device_ip = os.getenv("TEST_DEVICE_IP", "172.20.20.11")
     assert check_bgp_summary(device_ip)
 
 

--- a/tests/unit/test_collector_stack.py
+++ b/tests/unit/test_collector_stack.py
@@ -249,12 +249,17 @@ class TestSyslogPipeline:
     def test_alloy_mounts_config_readonly(self, services: dict):
         assert any("config.alloy" in v and v.endswith(":ro") for v in services["alloy"]["volumes"])
 
-    def test_alloy_config_listens_for_rfc3164_udp_syslog(self):
+    def test_alloy_config_listens_for_rfc5424_udp_syslog(self):
+        """SR Linux emits RSYSLOG_SyslogProtocol23Format (RFC5424-style) —
+        verified from the rsyslog config it generates on the device. An
+        rfc3164 listener drops every message with a parse error."""
         config = ALLOY_CONFIG_PATH.read_text()
         assert "loki.source.syslog" in config
         assert '"udp"' in config
-        assert "rfc3164" in config
-        assert "5514" in config
+        assert '"5514"' in config or ":5514" in config
+        settings = [line for line in config.splitlines() if "syslog_format" in line]
+        assert settings
+        assert all('"rfc5424"' in line for line in settings)
 
     def test_alloy_config_normalizes_device_label(self):
         """Syslog hostname is relabeled to the `device` label used by the

--- a/tests/unit/test_configure_syslog.py
+++ b/tests/unit/test_configure_syslog.py
@@ -16,9 +16,11 @@ config), so mirroring that on the remote-server captures everything.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from network_synapse.scripts.configure_syslog import (
     DEFAULT_COLLECTOR_HOST,
@@ -81,7 +83,7 @@ class TestConfigureSyslog:
         client = _mock_gnmi_client({"response": [{"op": "UPDATE"}]})
         mock_cls.return_value = client
 
-        result = configure_syslog("spine01", "clab-spine-leaf-lab-spine01", "172.20.20.1", 5514)
+        result = configure_syslog("spine01", "172.20.20.10", "172.20.20.1", 5514)
 
         assert result is True
         (kwargs_or_args,) = client.set.call_args_list
@@ -94,7 +96,7 @@ class TestConfigureSyslog:
     def test_returns_false_when_device_does_not_acknowledge(self, mock_cls: MagicMock):
         mock_cls.return_value = _mock_gnmi_client({})
 
-        assert configure_syslog("spine01", "clab-spine-leaf-lab-spine01", "172.20.20.1", 5514) is False
+        assert configure_syslog("spine01", "172.20.20.10", "172.20.20.1", 5514) is False
 
     @patch("network_synapse.scripts.configure_syslog.resolve_credentials", return_value=("u", "p"))
     @patch("network_synapse.scripts.configure_syslog.gNMIclient")
@@ -102,7 +104,7 @@ class TestConfigureSyslog:
         """Secrets come from gnmi_settings, never from call sites (Issue #166)."""
         mock_cls.return_value = _mock_gnmi_client({"response": []})
 
-        configure_syslog("spine01", "clab-spine-leaf-lab-spine01", "172.20.20.1", 5514)
+        configure_syslog("spine01", "172.20.20.10", "172.20.20.1", 5514)
 
         mock_resolve.assert_called_once()
         assert mock_cls.call_args.kwargs["username"] == "u"
@@ -116,9 +118,18 @@ class TestConfigureSyslog:
 
 @pytest.mark.unit
 class TestFabricDevices:
-    def test_targets_all_fabric_nodes_via_clab_dns(self):
+    def test_targets_all_fabric_nodes_via_pinned_mgmt_ips(self):
+        """The script runs on the macOS host, where containerlab DNS names do
+        not resolve (docker-network DNS only) — it must use the static
+        mgmt-ipv4 pins from topology.clab.yml (Issue #178)."""
         assert FABRIC_DEVICES == {
-            "spine01": "clab-spine-leaf-lab-spine01",
-            "leaf01": "clab-spine-leaf-lab-leaf01",
-            "leaf02": "clab-spine-leaf-lab-leaf02",
+            "spine01": "172.20.20.10",
+            "leaf01": "172.20.20.11",
+            "leaf02": "172.20.20.12",
         }
+
+    def test_fabric_ips_match_topology_pins(self):
+        topology_path = Path(__file__).parents[2] / "containerlab" / "topology.clab.yml"
+        nodes = yaml.safe_load(topology_path.read_text())["topology"]["nodes"]
+        for hostname, address in FABRIC_DEVICES.items():
+            assert nodes[hostname]["mgmt-ipv4"] == address

--- a/tests/unit/test_lab_mgmt_addressing.py
+++ b/tests/unit/test_lab_mgmt_addressing.py
@@ -1,0 +1,82 @@
+"""Unit tests for deterministic lab management addressing (Issue #178).
+
+The `clab` docker network (172.20.20.0/24) is shared with other containerlab
+deployments on the same host, and docker hands out dynamic addresses from
+the bottom of the subnet. Without static `mgmt-ipv4` pins, the SoT seed
+data's management IPs can end up pointing at *another project's* SR Linux
+nodes (same default credentials), so a workflow would push config to a
+foreign device.
+
+These tests pin the contract: every spine-leaf-lab node has a static
+mgmt-ipv4 above the dynamic-allocation zone, and the Infrahub seed data
+agrees with the topology exactly.
+"""
+
+from __future__ import annotations
+
+from ipaddress import IPv4Address, IPv4Network
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parents[2]
+TOPOLOGY_PATH = REPO_ROOT / "containerlab" / "topology.clab.yml"
+SEED_DATA_PATH = REPO_ROOT / "backend" / "network_synapse" / "data" / "seed_data.yml"
+
+MGMT_SUBNET = IPv4Network("172.20.20.0/24")
+# Other labs on the shared network draw dynamic addresses from the bottom
+# of the subnet; static pins must sit above this zone.
+DYNAMIC_ZONE_CEILING = IPv4Address("172.20.20.9")
+
+FABRIC_NODES = ("spine01", "leaf01", "leaf02")
+
+
+@pytest.fixture(scope="module")
+def topology() -> dict:
+    return yaml.safe_load(TOPOLOGY_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def topology_nodes(topology: dict) -> dict:
+    return topology["topology"]["nodes"]
+
+
+@pytest.fixture(scope="module")
+def seed_devices() -> dict[str, dict]:
+    seed = yaml.safe_load(SEED_DATA_PATH.read_text())
+    return {device["name"]: device for device in seed["devices"]}
+
+
+@pytest.mark.unit
+class TestTopologyMgmtPinning:
+    def test_mgmt_block_keeps_shared_clab_network(self, topology: dict):
+        """The collector stack and other labs coexist on the `clab` network —
+        the name and subnet must not change, only addressing determinism."""
+        mgmt = topology["mgmt"]
+        assert mgmt["network"] == "clab"
+        assert mgmt["ipv4-subnet"] == str(MGMT_SUBNET)
+
+    def test_every_node_has_static_mgmt_ip(self, topology_nodes: dict):
+        """All nodes pinned — a single dynamic node could race another lab
+        (or this lab's own pins) for an address at deploy time."""
+        for name, node in topology_nodes.items():
+            assert "mgmt-ipv4" in node, f"{name} has no static mgmt-ipv4"
+
+    def test_static_ips_are_above_the_dynamic_zone(self, topology_nodes: dict):
+        for name, node in topology_nodes.items():
+            address = IPv4Address(node["mgmt-ipv4"])
+            assert address in MGMT_SUBNET, f"{name}: {address} outside {MGMT_SUBNET}"
+            assert address > DYNAMIC_ZONE_CEILING, f"{name}: {address} inside the dynamic-allocation zone"
+
+    def test_static_ips_are_unique(self, topology_nodes: dict):
+        addresses = [node["mgmt-ipv4"] for node in topology_nodes.values()]
+        assert len(addresses) == len(set(addresses))
+
+
+@pytest.mark.unit
+class TestSeedDataMatchesTopology:
+    @pytest.mark.parametrize("hostname", FABRIC_NODES)
+    def test_seed_management_ip_matches_topology_pin(self, hostname: str, topology_nodes: dict, seed_devices: dict):
+        pinned = topology_nodes[hostname]["mgmt-ipv4"]
+        assert seed_devices[hostname]["management_ip"] == f"{pinned}/24"


### PR DESCRIPTION
Closes #178

## Summary

The `clab` docker network (172.20.20.0/24) is shared with other containerlab deployments on this host (e.g. the snapl project's dcfabric lab). Docker hands out dynamic addresses from the bottom of the subnet, and dcfabric currently holds .2–.7 — including **.2/.3/.4, the exact addresses the Infrahub seed data pinned for spine01/leaf01/leaf02**. A workflow started against the SoT's "spine01 @ 172.20.20.3" would have opened a gNMI session to `clab-dcfabric-leaf-03` (same default credentials) and pushed config to a foreign device.

### Fix
- Explicit `mgmt` block + static `mgmt-ipv4` pins for **all** spine-leaf-lab nodes: fabric .10–.12, firewall/pc1/pc2 .13–.15 — above the dynamic-allocation zone, following the pattern already used by `containerlab/topologies/*.clab.yml`. Network name/subnet unchanged, so the collector stack (#169) and other labs keep coexisting.
- `seed_data.yml`, docs, skills, conftest header, and e2e/integration test defaults aligned with the pins.

**Verified live**: deployed spine-leaf-lab alongside the running dcfabric lab — dcfabric keeps .2–.7, our nodes land exactly on .10–.15, zero overlap; gNMI reachable on the pinned addresses.

### Bugs found & fixed while verifying end-to-end
- **`dev.lab-*` tasks were broken on OrbStack** (explains the lab containers dead for 3 months): containerlab-in-docker cannot resolve node netns paths without `--pid host` — every deploy failed with "namespace path not available". Added the flag to `_clab_docker_cmd`.
- **`configure_syslog.py` now targets the pinned IPs**: containerlab DNS names resolve only on the docker network, not from the macOS host (empirically confirmed — the containerlab skill's claim to the contrary is corrected).
- **Alloy syslog listener switched rfc3164 → rfc5424**: SR Linux emits `RSYSLOG_SyslogProtocol23Format` (verified from the rsyslog config it generates on-device); the rfc3164 parser dropped every message ("expecting a sequence number").

With these, the full #169 acceptance now passes against the real lab: gnmic streams normalized metrics from all 3 nodes, `invoke dev.lab-syslog` returns OK for all 3 devices, and their syslog (sr_aaa_mgr, sr_grpc_server, …) is queryable in Loki with `device`/`app`/`severity`/`facility` labels. Lab config change made during testing was reverted.

## Test plan
- TDD: `tests/unit/test_lab_mgmt_addressing.py` (7 tests — pins exist, unique, above the dynamic zone, seed data matches topology exactly) + updated collector/syslog tests
- Full unit suite: 524 passed, coverage 80.94%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoFdWcb9vSNaGCiZMTVjrn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic management IP assignments for Containerlab nodes.
  * Improved host-side connectivity by using pinned management addresses.
  * Updated syslog collection to support RFC5424-formatted messages.

* **Documentation**
  * Updated infrastructure, runbook, telemetry, and lab guidance with the new management addresses and syslog format.

* **Bug Fixes**
  * Improved container-based tooling compatibility on OrbStack environments.

* **Tests**
  * Updated integration and end-to-end checks for static management addressing and RFC5424 syslog validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->